### PR TITLE
SLING-10192 Add option to set/edit properties on users and groups

### DIFF
--- a/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
@@ -128,4 +128,173 @@ public class SetPropertiesTest {
         U.assertSVPropertyExists(path3, "one", vf.createValue("oneB"));
         U.assertSVPropertyExists(path3, "two", vf.createValue("twoA"));
     }
+
+    @Test
+    public void setUserProperties() throws Exception {
+        String userid = "user" + UUID.randomUUID();
+
+        U.assertUser("before creating user", userid, false);
+        U.parseAndExecute("create user " + userid);
+        U.assertUser("after creating user", userid, true);
+
+        assertAuthorizableProperties(userid);
+        assertAuthorizablePropertiesAgain(userid);
+    }
+
+    @Test
+    public void setSubTreeUserProperties() throws Exception {
+        String userid = "user" + UUID.randomUUID();
+
+        U.assertUser("before creating user", userid, false);
+        U.parseAndExecute("create user " + userid);
+        U.assertUser("after creating user", userid, true);
+
+        assertAuthorizableSubTreeProperties(userid);
+        assertAuthorizableSubTreePropertiesAgain(userid);
+    }
+
+    @Test
+    public void setGroupProperties() throws Exception {
+        String groupid = "group" + UUID.randomUUID();
+
+        U.assertGroup("before creating group", groupid, false);
+        U.parseAndExecute("create group " + groupid);
+        U.assertGroup("after creating group", groupid, true);
+
+        assertAuthorizableProperties(groupid);
+        assertAuthorizablePropertiesAgain(groupid);
+    }
+
+    @Test
+    public void setSubTreeGroupProperties() throws Exception {
+        String groupid = "group" + UUID.randomUUID();
+
+        U.assertGroup("before creating group", groupid, false);
+        U.parseAndExecute("create group " + groupid);
+        U.assertGroup("after creating group", groupid, true);
+
+        assertAuthorizableSubTreeProperties(groupid);
+        assertAuthorizableSubTreePropertiesAgain(groupid);
+    }
+
+    /**
+     * Set properties on an authorizable and then verify that the values were set
+     */
+    protected void assertAuthorizableProperties(String id) throws RepositoryException, RepoInitParsingException {
+        final String setPropsA =
+                "set properties on authorizable(" +id + ")\n"
+                        + "set one to oneA\n"
+                        + "default two to twoA\n"
+                        + "set nested/one to oneA\n"
+                        + "default nested/two to twoA\n"
+                        + "set three to threeA, \"threeB\", threeC\n"
+                        + "default four to fourA, \"fourB\"\n"
+                        + "set nested/three to threeA, \"threeB\", threeC\n"
+                        + "default nested/four to fourA, \"fourB\"\n"
+                + "end";
+
+        U.parseAndExecute(setPropsA);
+
+        U.assertAuthorizableSVPropertyExists(id, "one", vf.createValue("oneA"));
+        U.assertAuthorizableSVPropertyExists(id, "nested/one", vf.createValue("oneA"));
+        U.assertAuthorizableSVPropertyExists(id, "two", vf.createValue("twoA"));
+        U.assertAuthorizableSVPropertyExists(id, "nested/two", vf.createValue("twoA"));
+        U.assertAuthorizableMVPropertyExists(id, "three", new Value[] {
+                vf.createValue("threeA"),
+                vf.createValue("threeB"),
+                vf.createValue("threeC")
+                });
+        U.assertAuthorizableMVPropertyExists(id, "nested/three", new Value[] {
+                vf.createValue("threeA"),
+                vf.createValue("threeB"),
+                vf.createValue("threeC")
+                });
+        U.assertAuthorizableMVPropertyExists(id, "four", new Value[] {
+                vf.createValue("fourA"),
+                vf.createValue("fourB")
+                });
+        U.assertAuthorizableMVPropertyExists(id, "nested/four", new Value[] {
+                vf.createValue("fourA"),
+                vf.createValue("fourB")
+                });
+    }
+
+    /**
+     * Change values for existing properties on an authorizable and then verify that the values were set
+     * or not as appropriate
+     */
+    protected void assertAuthorizablePropertiesAgain(String id) throws RepositoryException, RepoInitParsingException {
+        final String setPropsA =
+                "set properties on authorizable(" + id + ")\n"
+                        + "set one to changed_oneA\n"
+                        + "default two to changed_twoA\n"
+                        + "set nested/one to changed_oneA\n"
+                        + "default nested/two to changed_twoA\n"
+                        + "set three to changed_threeA, \"changed_threeB\", changed_threeC\n"
+                        + "default four to changed_fourA, \"changed_fourB\"\n"
+                        + "set nested/three to changed_threeA, \"changed_threeB\", changed_threeC\n"
+                        + "default nested/four to changed_fourA, \"changed_fourB\"\n"
+                + "end";
+
+        U.parseAndExecute(setPropsA);
+
+        U.assertAuthorizableSVPropertyExists(id, "one", vf.createValue("changed_oneA"));
+        U.assertAuthorizableSVPropertyExists(id, "nested/one", vf.createValue("changed_oneA"));
+        U.assertAuthorizableSVPropertyExists(id, "two", vf.createValue("twoA"));
+        U.assertAuthorizableSVPropertyExists(id, "nested/two", vf.createValue("twoA"));
+        U.assertAuthorizableMVPropertyExists(id, "three", new Value[] {
+                vf.createValue("changed_threeA"),
+                vf.createValue("changed_threeB"),
+                vf.createValue("changed_threeC")
+                });
+        U.assertAuthorizableMVPropertyExists(id, "nested/three", new Value[] {
+                vf.createValue("changed_threeA"),
+                vf.createValue("changed_threeB"),
+                vf.createValue("changed_threeC")
+                });
+        U.assertAuthorizableMVPropertyExists(id, "four", new Value[] {
+                vf.createValue("fourA"),
+                vf.createValue("fourB")
+                });
+        U.assertAuthorizableMVPropertyExists(id, "nested/four", new Value[] {
+                vf.createValue("fourA"),
+                vf.createValue("fourB")
+                });
+    }
+
+    /**
+     * Set properties on a subtree of an authorizable and then verify that the values were set
+     */
+    protected void assertAuthorizableSubTreeProperties(String id)
+            throws RepositoryException, RepoInitParsingException {
+        final String setPropsA =
+                "set properties on authorizable(" + id + ")/nested\n"
+                        + "set one to oneA\n"
+                        + "default two to twoA\n"
+                + "end";
+
+        U.parseAndExecute(setPropsA);
+
+        U.assertAuthorizableSVPropertyExists(id, "nested/one", vf.createValue("oneA"));
+        U.assertAuthorizableSVPropertyExists(id, "nested/two", vf.createValue("twoA"));
+    }
+
+    /**
+     * Change values for existing properties on a subtree of an authorizable and then verify 
+     * that the values were set or not as appropriate
+     */
+    protected void assertAuthorizableSubTreePropertiesAgain(String id)
+            throws RepositoryException, RepoInitParsingException {
+        final String setPropsA =
+                "set properties on authorizable(" + id + ")/nested\n"
+                        + "set one to changed_oneA\n"
+                        + "default two to changed_twoA\n"
+                + "end";
+
+        U.parseAndExecute(setPropsA);
+
+        U.assertAuthorizableSVPropertyExists(id, "nested/one", vf.createValue("changed_oneA"));
+        U.assertAuthorizableSVPropertyExists(id, "nested/two", vf.createValue("twoA"));
+    }
+
 }

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/TestUtil.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/TestUtil.java
@@ -197,6 +197,32 @@ public class TestUtil {
         assertEquals(message +  " to be member of " + groupId, expectToBeMember, isMember);
     }
 
+    public void assertAuthorizableSVPropertyExists(String id, String propertyName, Value expectedValue) throws RepositoryException {
+        final Authorizable a = UserUtil.getAuthorizable(adminSession, id);
+        assertNotNull("failed to get authorizable for " + id, a);
+        if (!a.hasProperty(propertyName)) {
+            fail("No " + propertyName + " property for " + a.getID());
+        } else {
+            Value[] property = a.getProperty(propertyName);
+            assertNotNull("Expected non-null value for property: " + propertyName, property);
+            assertEquals("Expected one value for property: " + propertyName, 1, property.length);
+            Value actualValue = property[0];
+            assertEquals("Value mismatch for property: " + propertyName, expectedValue, actualValue);
+        }
+    }
+
+    public void assertAuthorizableMVPropertyExists(String id, String propertyName, Value[] expectedValues) throws RepositoryException {
+        final Authorizable a = UserUtil.getAuthorizable(adminSession, id);
+        assertNotNull("failed to get authorizable for " + id, a);
+        if (!a.hasProperty(propertyName)) {
+            fail("No " + propertyName + " property for " + a.getID());
+        } else {
+            Value[] actualValues = a.getProperty(propertyName);
+            assertNotNull("Expected non-null value for property: " + propertyName, actualValues);
+            assertArrayEquals("Values mismatch for property: " + propertyName, expectedValues, actualValues);
+        }
+    }
+
     public void assertSVPropertyExists(String path, String propertyName, Value expectedValue) throws RepositoryException {
         final Node n = adminSession.getNode(path);
         if(!n.hasProperty(propertyName)) {

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTextIT.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTextIT.java
@@ -24,11 +24,14 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.UUID;
 
-import javax.jcr.PropertyType;
-import javax.jcr.ValueFactory;
-import javax.jcr.Value;
 import javax.inject.Inject;
+import javax.jcr.PropertyType;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.sling.jcr.repoinit.JcrRepoInitOpsProcessor;
 import org.apache.sling.repoinit.parser.RepoInitParser;
 import org.junit.Before;
@@ -206,6 +209,128 @@ public class RepoInitTextIT extends RepoInitTestSupport {
                 expectedValues9[1] = vf.createValue("non-quoted");
                 expectedValues9[2] = vf.createValue("the last \" one");
                 assertTrue("Expecting string array type property " + PROP_I + " to be present " , U.hasProperty(session, PROP_NODE_PATH, PROP_I, expectedValues9));
+
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void setAuthorizableProperties() throws Exception {
+        new Retry() {
+            @Override
+            public Void call() throws Exception {
+                if(!(session instanceof JackrabbitSession)) {
+                    throw new IllegalArgumentException("Session is not a JackrabbitSession");
+                }
+                UserManager um = ((JackrabbitSession)session).getUserManager();
+
+                Authorizable [] authorizables = new Authorizable[] {
+                        um.getAuthorizable(ALICE),
+                        um.getAuthorizable(GROUP_A)
+                };
+
+                for (Authorizable authorizable : authorizables) {
+                    assertNotNull("Expected authorizable to not be null", authorizable);
+                    ValueFactory vf = session.getValueFactory();
+                    Value[] expectedValues1 = new Value[2];
+                    expectedValues1[0] = vf.createValue("/d/e/f/*");
+                    expectedValues1[1] = vf.createValue("m/n/*");
+                    assertTrue("Expecting array type property " + PROP_A + " to be present ", U.hasProperty(authorizable, PROP_A, expectedValues1));
+
+                    Value expectedValue2 = vf.createValue("42", PropertyType.valueFromName("Long"));
+                    assertTrue("Expecting Long type default property " + PROP_B + " to be present ", U.hasProperty(authorizable, PROP_B, expectedValue2));
+
+                    Value expectedValue3  = vf.createValue("true", PropertyType.valueFromName("Boolean"));
+                    assertTrue("Expecting bool type property " + PROP_C + " to be present ", U.hasProperty(authorizable, PROP_C, expectedValue3));
+
+                    Value expectedValue4 = vf.createValue("2020-03-19T11:39:33.437+05:30", PropertyType.valueFromName("Date"));
+                    assertTrue("Expecting date type property " + PROP_D + " to be present " , U.hasProperty(authorizable, PROP_D, expectedValue4));
+
+                    Value expectedValue5 = vf.createValue("test");
+                    assertTrue("Expecting string type property " + PROP_E + " to be present " , U.hasProperty(authorizable, PROP_E, expectedValue5));
+
+                    Value expectedValue6 = vf.createValue("hello, you!");
+                    assertTrue("Expecting quoted string type property " + PROP_F + " to be present " , U.hasProperty(authorizable, PROP_F, expectedValue6));
+
+                    Value[] expectedValues7 = new Value[2];
+                    expectedValues7[0] = vf.createValue("test1");
+                    expectedValues7[1] = vf.createValue("test2");
+                    assertTrue("Expecting string array type property " + PROP_G + " to be present " , U.hasProperty(authorizable, PROP_G, expectedValues7));
+
+                    Value expectedValue8 = vf.createValue("Here's a \"double quoted string\" with suffix");
+                    assertTrue("Expecting quoted string type property " + PROP_H + " to be present " , U.hasProperty(authorizable, PROP_H, expectedValue8));
+
+                    Value[] expectedValues9 = new Value[3];
+                    expectedValues9[0] = vf.createValue("quoted");
+                    expectedValues9[1] = vf.createValue("non-quoted");
+                    expectedValues9[2] = vf.createValue("the last \" one");
+                    assertTrue("Expecting string array type property " + PROP_I + " to be present " , U.hasProperty(authorizable, PROP_I, expectedValues9));
+
+                    Value nestedExpectedValue = vf.createValue("42", PropertyType.valueFromName("Long"));
+                    assertTrue("Expecting Long type default property nested/" + PROP_B + " to be present ", U.hasProperty(authorizable, "nested/" +PROP_B, nestedExpectedValue));
+                }
+
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void setAuthorizableSubTreeProperties() throws Exception {
+        new Retry() {
+            @Override
+            public Void call() throws Exception {
+                if(!(session instanceof JackrabbitSession)) {
+                    throw new IllegalArgumentException("Session is not a JackrabbitSession");
+                }
+                UserManager um = ((JackrabbitSession)session).getUserManager();
+
+                Authorizable [] authorizables = new Authorizable[] {
+                        um.getAuthorizable(BOB),
+                        um.getAuthorizable(GROUP_B)
+                };
+
+                for (Authorizable authorizable : authorizables) {
+                    assertNotNull("Expected authorizable to not be null", authorizable);
+                    ValueFactory vf = session.getValueFactory();
+                    Value[] expectedValues1 = new Value[2];
+                    expectedValues1[0] = vf.createValue("/d/e/f/*");
+                    expectedValues1[1] = vf.createValue("m/n/*");
+                    assertTrue("Expecting array type property nested/" + PROP_A + " to be present ", U.hasProperty(authorizable, "nested/" + PROP_A, expectedValues1));
+
+                    Value expectedValue2 = vf.createValue("42", PropertyType.valueFromName("Long"));
+                    assertTrue("Expecting Long type default property nested/" + PROP_B + " to be present ", U.hasProperty(authorizable, "nested/" + PROP_B, expectedValue2));
+
+                    Value expectedValue3  = vf.createValue("true", PropertyType.valueFromName("Boolean"));
+                    assertTrue("Expecting bool type property nested/" + PROP_C + " to be present ", U.hasProperty(authorizable, "nested/" + PROP_C, expectedValue3));
+
+                    Value expectedValue4 = vf.createValue("2020-03-19T11:39:33.437+05:30", PropertyType.valueFromName("Date"));
+                    assertTrue("Expecting date type property nested/" + PROP_D + " to be present " , U.hasProperty(authorizable, "nested/" + PROP_D, expectedValue4));
+
+                    Value expectedValue5 = vf.createValue("test");
+                    assertTrue("Expecting string type property nested/" + PROP_E + " to be present " , U.hasProperty(authorizable, "nested/" + PROP_E, expectedValue5));
+
+                    Value expectedValue6 = vf.createValue("hello, you!");
+                    assertTrue("Expecting quoted string type property nested/" + PROP_F + " to be present " , U.hasProperty(authorizable, "nested/" + PROP_F, expectedValue6));
+
+                    Value[] expectedValues7 = new Value[2];
+                    expectedValues7[0] = vf.createValue("test1");
+                    expectedValues7[1] = vf.createValue("test2");
+                    assertTrue("Expecting string array type property nested/" + PROP_G + " to be present " , U.hasProperty(authorizable, "nested/" + PROP_G, expectedValues7));
+
+                    Value expectedValue8 = vf.createValue("Here's a \"double quoted string\" with suffix");
+                    assertTrue("Expecting quoted string type property nested/" + PROP_H + " to be present " , U.hasProperty(authorizable, "nested/" + PROP_H, expectedValue8));
+
+                    Value[] expectedValues9 = new Value[3];
+                    expectedValues9[0] = vf.createValue("quoted");
+                    expectedValues9[1] = vf.createValue("non-quoted");
+                    expectedValues9[2] = vf.createValue("the last \" one");
+                    assertTrue("Expecting string array type property nested/" + PROP_I + " to be present " , U.hasProperty(authorizable, "nested/" + PROP_I, expectedValues9));
+
+                    Value nestedExpectedValue = vf.createValue("42", PropertyType.valueFromName("Long"));
+                    assertTrue("Expecting Long type default property nested/nested/" + PROP_B + " to be present ", U.hasProperty(authorizable, "nested/nested/" +PROP_B, nestedExpectedValue));
+                }
 
                 return null;
             }

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/U.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/U.java
@@ -135,4 +135,29 @@ public class U {
         }
         return false;
     }
+
+    public static boolean hasProperty(Authorizable a, String propertyName, Value propertyValue) throws  RepositoryException {
+        if (a != null) {
+            boolean isPropertyPresent = a.hasProperty(propertyName);
+            if (isPropertyPresent) {
+                Value[] values = a.getProperty(propertyName);
+                if (values != null && values.length == 1) {
+                    Value v = values[0];
+                    return v.equals(propertyValue);
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean hasProperty(Authorizable a, String propertyName, Value[] propertyValues) throws  RepositoryException {
+        if (a != null) {
+            boolean isPropertyPresent = a.hasProperty(propertyName);
+            if (isPropertyPresent) {
+                Value[] v = a.getProperty(propertyName);
+                return Arrays.equals(v, propertyValues);
+            }
+        }
+        return false;
+    }
 }

--- a/src/test/resources/repoinit.txt
+++ b/src/test/resources/repoinit.txt
@@ -82,3 +82,33 @@ set properties on /proptest/X/Y
   set quotedA to "Here's a \"double quoted string\" with suffix"
   set quotedMix to "quoted", non-quoted, "the last \" one"
 end
+
+# SLING-10192 set properties on user or group profile
+set properties on authorizable(alice),authorizable(grpA)
+  set pathArray to /d/e/f/*, m/n/*
+  default someInteger{Long} to 42
+  set someFlag{Boolean} to true
+  default someDate{Date} to "2020-03-19T11:39:33.437+05:30"
+  set customSingleValueStringProp to test
+  set customSingleValueQuotedStringProp to "hello, you!"
+  set stringArray to test1, test2
+  default someInteger{Long} to 65
+  set quotedA to "Here's a \"double quoted string\" with suffix"
+  set quotedMix to "quoted", non-quoted, "the last \" one"
+  set nested/someInteger{Long} to 42
+end
+
+# SLING-10192 set properties on a subtree of the user or group profile
+set properties on authorizable(bob)/nested,authorizable(grpB)/nested
+  set pathArray to /d/e/f/*, m/n/*
+  default someInteger{Long} to 42
+  set someFlag{Boolean} to true
+  default someDate{Date} to "2020-03-19T11:39:33.437+05:30"
+  set customSingleValueStringProp to test
+  set customSingleValueQuotedStringProp to "hello, you!"
+  set stringArray to test1, test2
+  default someInteger{Long} to 65
+  set quotedA to "Here's a \"double quoted string\" with suffix"
+  set quotedMix to "quoted", non-quoted, "the last \" one"
+  set nested/someInteger{Long} to 42
+end


### PR DESCRIPTION
For: [SLING-10192](https://issues.apache.org/jira/browse/SLING-10192)

Use Case: repoinit should be able to set properties on users and groups that were just created

The solution here could be similar to how SLING-8757 added the syntax to set ACL on the user home folder but for the "set properties" action.

I'm thinking of a path syntax of authorizable(id) instead of home(id) to maintain the abstraction between the Authorizable apis and where those are stored. 

The syntax would look something like this:
```
# set properties on user or group profile
set properties on authorizable(alice),authorizable(grpA)
  set pathArray to /d/e/f/*, m/n/*
  default someInteger{Long} to 42
  set someFlag{Boolean} to true
  default someDate{Date} to "2020-03-19T11:39:33.437+05:30"
  set customSingleValueStringProp to test
  set customSingleValueQuotedStringProp to "hello, you!"
  set stringArray to test1, test2
  default someInteger{Long} to 65
  set quotedA to "Here's a \"double quoted string\" with suffix"
  set quotedMix to "quoted", non-quoted, "the last \" one"
  set nested/someInteger{Long} to 42
end

# set properties on a subtree of the user or group profile
set properties on authorizable(bob)/nested,authorizable(grpB)/nested
  set pathArray to /d/e/f/*, m/n/*
  default someInteger{Long} to 42
  set someFlag{Boolean} to true
  default someDate{Date} to "2020-03-19T11:39:33.437+05:30"
  set customSingleValueStringProp to test
  set customSingleValueQuotedStringProp to "hello, you!"
  set stringArray to test1, test2
  default someInteger{Long} to 65
  set quotedA to "Here's a \"double quoted string\" with suffix"
  set quotedMix to "quoted", non-quoted, "the last \" one"
  set nested/someInteger{Long} to 42
end
```