### PR TITLE
SLING-11160 : Repoinit does not allow to remove individual ACEs (jcr impl)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.repoinit.parser</artifactId>
-            <version>1.6.11-SNAPSHOT</version>
+            <version>1.6.13-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/AclVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/AclVisitor.java
@@ -72,11 +72,11 @@ class AclVisitor extends DoNothingVisitor {
     private void setAcl(AclLine line, Session s, List<String> principals, List<String> paths, List<String> privileges, AclLine.Action action) {
         try {
             if (action == AclLine.Action.REMOVE) {
-                report("remove not supported");
+                AclUtil.removeEntries(s, principals, paths, privileges, line.isAllow(), line.getRestrictions());
             } else if (action == AclLine.Action.REMOVE_ALL) {
                 AclUtil.removeEntries(s, principals, paths);
             } else {
-                final boolean isAllow = line.getAction().equals(AclLine.Action.ALLOW);
+                final boolean isAllow = line.isAllow();
                 log.info("Adding ACL '{}' entry '{}' for {} on {}", isAllow ? "allow" : "deny", privileges, principals, paths);
                 List<RestrictionClause> restrictions = line.getRestrictions();
                 AclUtil.setAcl(s, principals, paths, privileges, isAllow, restrictions);
@@ -89,11 +89,11 @@ class AclVisitor extends DoNothingVisitor {
     private void setRepositoryAcl(AclLine line, Session s, List<String> principals, List<String> privileges, AclLine.Action action) {
         try {
             if (action == AclLine.Action.REMOVE) {
-                report("remove not supported");
+                AclUtil.removeEntries(s, principals, Collections.singletonList(null), privileges, line.isAllow(), line.getRestrictions());
             } else if (action == AclLine.Action.REMOVE_ALL) {
                 AclUtil.removeEntries(s, principals, Collections.singletonList(null));
             } else {
-                final boolean isAllow = line.getAction().equals(AclLine.Action.ALLOW);
+                final boolean isAllow = line.isAllow();
                 log.info("Adding repository level ACL '{}' entry '{}' for {}", isAllow ? "allow" : "deny", privileges, principals);
                 List<RestrictionClause> restrictions = line.getRestrictions();
                 AclUtil.setRepositoryAcl(s, principals, privileges, isAllow, restrictions);

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/AclVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/AclVisitor.java
@@ -34,9 +34,9 @@ import org.apache.sling.repoinit.parser.operations.DeleteAclPrincipalBased;
 import org.apache.sling.repoinit.parser.operations.DeleteAclPrincipals;
 import org.apache.sling.repoinit.parser.operations.PathSegmentDefinition;
 import org.apache.sling.repoinit.parser.operations.DeleteAclPaths;
-import org.apache.sling.repoinit.parser.operations.RemoveAclPaths;
-import org.apache.sling.repoinit.parser.operations.RemoveAclPrincipalBased;
-import org.apache.sling.repoinit.parser.operations.RemoveAclPrincipals;
+import org.apache.sling.repoinit.parser.operations.RemoveAcePaths;
+import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipalBased;
+import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipals;
 import org.apache.sling.repoinit.parser.operations.RestrictionClause;
 import org.apache.sling.repoinit.parser.operations.SetAclPaths;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipalBased;
@@ -140,7 +140,7 @@ class AclVisitor extends DoNothingVisitor {
     }
 
     @Override
-    public void visitRemoveAclPrincipal(RemoveAclPrincipals s) {
+    public void visitRemoveAcePrincipal(RemoveAcePrincipals s) {
         final List<String> principals = s.getPrincipals();
         for (AclLine line : s.getLines()) {
             final List<String> paths = line.getProperty(PROP_PATHS);
@@ -153,7 +153,7 @@ class AclVisitor extends DoNothingVisitor {
     }
 
     @Override
-    public void visitRemoveAclPaths(RemoveAclPaths s) {
+    public void visitRemoveAcePaths(RemoveAcePaths s) {
         final List<String> paths = s.getPaths();
         for (AclLine line : s.getLines()) {
             try {
@@ -165,7 +165,7 @@ class AclVisitor extends DoNothingVisitor {
     }
 
     @Override
-    public void visitRemoveAclPrincipalBased(RemoveAclPrincipalBased s) {
+    public void visitRemoveAcePrincipalBased(RemoveAcePrincipalBased s) {
         for (String principalName : s.getPrincipals()) {
             try {
                 log.info("Removing principal-based access control entries for {}", principalName);

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/DoNothingVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/DoNothingVisitor.java
@@ -34,6 +34,9 @@ import org.apache.sling.repoinit.parser.operations.RegisterNodetypes;
 import org.apache.sling.repoinit.parser.operations.RegisterPrivilege;
 import org.apache.sling.repoinit.parser.operations.DeleteAclPaths;
 import org.apache.sling.repoinit.parser.operations.DeleteAclPrincipalBased;
+import org.apache.sling.repoinit.parser.operations.RemoveAclPaths;
+import org.apache.sling.repoinit.parser.operations.RemoveAclPrincipalBased;
+import org.apache.sling.repoinit.parser.operations.RemoveAclPrincipals;
 import org.apache.sling.repoinit.parser.operations.RemoveGroupMembers;
 import org.apache.sling.repoinit.parser.operations.SetAclPaths;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipalBased;
@@ -97,6 +100,18 @@ class DoNothingVisitor implements OperationVisitor {
 
     @Override
     public void visitSetAclPaths(SetAclPaths s) {
+    }
+
+    @Override
+    public void visitRemoveAclPrincipal(RemoveAclPrincipals s) {
+    }
+
+    @Override
+    public void visitRemoveAclPaths(RemoveAclPaths s) {
+    }
+
+    @Override
+    public void visitRemoveAclPrincipalBased(RemoveAclPrincipalBased s) {
     }
 
     @Override

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/DoNothingVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/DoNothingVisitor.java
@@ -34,9 +34,9 @@ import org.apache.sling.repoinit.parser.operations.RegisterNodetypes;
 import org.apache.sling.repoinit.parser.operations.RegisterPrivilege;
 import org.apache.sling.repoinit.parser.operations.DeleteAclPaths;
 import org.apache.sling.repoinit.parser.operations.DeleteAclPrincipalBased;
-import org.apache.sling.repoinit.parser.operations.RemoveAclPaths;
-import org.apache.sling.repoinit.parser.operations.RemoveAclPrincipalBased;
-import org.apache.sling.repoinit.parser.operations.RemoveAclPrincipals;
+import org.apache.sling.repoinit.parser.operations.RemoveAcePaths;
+import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipalBased;
+import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipals;
 import org.apache.sling.repoinit.parser.operations.RemoveGroupMembers;
 import org.apache.sling.repoinit.parser.operations.SetAclPaths;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipalBased;
@@ -103,19 +103,19 @@ class DoNothingVisitor implements OperationVisitor {
     }
 
     @Override
-    public void visitRemoveAclPrincipal(RemoveAclPrincipals s) {
-    }
-
-    @Override
-    public void visitRemoveAclPaths(RemoveAclPaths s) {
-    }
-
-    @Override
-    public void visitRemoveAclPrincipalBased(RemoveAclPrincipalBased s) {
-    }
-
-    @Override
     public void visitSetAclPrincipalBased(SetAclPrincipalBased operation) {
+    }
+
+    @Override
+    public void visitRemoveAcePrincipal(RemoveAcePrincipals s) {
+    }
+
+    @Override
+    public void visitRemoveAcePaths(RemoveAcePaths s) {
+    }
+
+    @Override
+    public void visitRemoveAcePrincipalBased(RemoveAcePrincipalBased s) {
     }
 
     @Override

--- a/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
@@ -710,7 +710,30 @@ public class PrincipalBasedAclTest {
         U.parseAndExecute(setup);
         assertPolicy(principal, U.adminSession, 1);
 
+        setup = "remove principal ACE for " + U.username + "\n"
+                + "allow jcr:write on " + path + "\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(principal, U.adminSession, 0);
+    }
+
+    @Test
+    public void testRemoveNoMatchingEntry() throws Exception {
+        Principal principal = getPrincipal(U.username);
+        String setup = "set principal ACL for " + U.username + "\n"
+                + "allow jcr:write on "+path+"\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(principal, U.adminSession, 1);
+
         // privilege mismatch
+        setup = "remove principal ACE for " + U.username + "\n"
+                + "allow jcr:read on " + path + "\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(principal, U.adminSession, 1);
+
+        // privilege mismatch 2
         setup = "remove principal ACE for " + U.username + "\n"
                 + "allow jcr:read,jcr:write on " + path + "\n"
                 + "end";
@@ -729,21 +752,6 @@ public class PrincipalBasedAclTest {
                 + "allow jcr:write on " + path + " restriction(rep:glob, /*/jcr:content/*)\n"
                 + "end";
         U.parseAndExecute(setup);
-        assertPolicy(principal, U.adminSession, 1);
-    }
-
-    @Test
-    public void testRemoveNoMatchingEntry() throws Exception {
-        Principal principal = getPrincipal(U.username);
-        String setup = "set principal ACL for " + U.username + "\n"
-                + "allow jcr:write on "+path+"\n"
-                + "end";
-        U.parseAndExecute(setup);
-        assertPolicy(principal, U.adminSession, 1);
-
-        setup = "remove principal ACE for " + U.username + "\n"
-                + "allow jcr:read on " + path + "\n"
-                + "end";
         assertPolicy(principal, U.adminSession, 1);
     }
 

--- a/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
@@ -695,7 +695,7 @@ public class PrincipalBasedAclTest {
 
     @Test
     public void testRemoveNoExistingPolicy() throws Exception {
-        String setup = "remove principal ACL for " + U.username + "\n"
+        String setup = "remove principal ACE for " + U.username + "\n"
                 + "allow jcr:read on " + path + "\n"
                 + "end";
         U.parseAndExecute(setup);
@@ -711,21 +711,21 @@ public class PrincipalBasedAclTest {
         assertPolicy(principal, U.adminSession, 1);
 
         // privilege mismatch
-        setup = "remove principal ACL for " + U.username + "\n"
+        setup = "remove principal ACE for " + U.username + "\n"
                 + "allow jcr:read,jcr:write on " + path + "\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(principal, U.adminSession, 1);
 
         // path mismatch
-        setup = "remove principal ACL for " + U.username + "\n"
+        setup = "remove principal ACE for " + U.username + "\n"
                 + "allow jcr:write on " + path + "/mismatch\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(principal, U.adminSession, 1);
 
         // restriction mismatch
-        setup = "remove principal ACL for " + U.username + "\n"
+        setup = "remove principal ACE for " + U.username + "\n"
                 + "allow jcr:write on " + path + " restriction(rep:glob, /*/jcr:content/*)\n"
                 + "end";
         U.parseAndExecute(setup);
@@ -741,7 +741,7 @@ public class PrincipalBasedAclTest {
         U.parseAndExecute(setup);
         assertPolicy(principal, U.adminSession, 1);
 
-        setup = "remove principal ACL for " + U.username + "\n"
+        setup = "remove principal ACE for " + U.username + "\n"
                 + "allow jcr:read on " + path + "\n"
                 + "end";
         assertPolicy(principal, U.adminSession, 1);
@@ -749,7 +749,7 @@ public class PrincipalBasedAclTest {
 
     @Test(expected = RepoInitException.class)
     public void testRemoveNonExistingPrincipal() throws Exception {
-        String setup = "remove principal ACL for nonExistingPrincipal\n"
+        String setup = "remove principal ACE for nonExistingPrincipal\n"
                 + "deny jcr:write on " + path + "\n"
                 + "end";
         U.parseAndExecute(setup);
@@ -764,7 +764,7 @@ public class PrincipalBasedAclTest {
         U.parseAndExecute("create service user otherSystemPrincipal");
         assertPolicy(getPrincipal(U.username), U.adminSession, 1);
 
-        setup = "remove principal ACL for otherSystemPrincipal\n"
+        setup = "remove principal ACE for otherSystemPrincipal\n"
                 + "allow jcr:write on " + path + "\n"
                 + "end";
         U.parseAndExecute(setup);

--- a/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
@@ -174,21 +174,21 @@ public class RemoveTest {
     @Test
     public void testRemoveByPath() throws RepoInitParsingException, RepositoryException {
         // non-matching ACE (path-mismatch) -> not removed (and no exception)
-        String setup = "remove ACL for " + U.username + "\n"
+        String setup = "remove ACE for " + U.username + "\n"
                 + "deny jcr:read on /\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(path, U.adminSession, 2);
 
         // non-matching ACE (privilege-mismatch) -> not removed (and no exception)
-        setup = "remove ACL for " + U.username + "\n"
+        setup = "remove ACE for " + U.username + "\n"
                 + "deny jcr:read,jcr:write on "+path+"\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(path, U.adminSession, 2);
 
         // matching ACE -> removed
-        setup = "remove ACL for " + U.username + "\n"
+        setup = "remove ACE for " + U.username + "\n"
                 + "deny jcr:read on "+path+"\n"
                 + "end";
         U.parseAndExecute(setup);
@@ -198,14 +198,14 @@ public class RemoveTest {
     @Test
     public void testRemoveByRepository() throws RepoInitParsingException, RepositoryException {
         // non-matching ACE (allow mismatch) -> not removed (and no exception)
-        String setup = "remove ACL for " + groupPrincipalName + "\n"
+        String setup = "remove ACE for " + groupPrincipalName + "\n"
                 + "deny jcr:namespaceManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(null, U.adminSession, 2);
 
         // matching ACE -> removed
-        setup = "remove ACL for " + groupPrincipalName + "\n"
+        setup = "remove ACE for " + groupPrincipalName + "\n"
                 + "allow jcr:namespaceManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
@@ -215,14 +215,14 @@ public class RemoveTest {
     @Test
     public void testRemoveByPrincipalRepositoryPath() throws RepoInitParsingException, RepositoryException {
         // non-matching ACE (privilege mismatch) -> not removed (and no exception)
-        String setup = "remove ACL for " + groupPrincipalName + "\n"
+        String setup = "remove ACE for " + groupPrincipalName + "\n"
                 + "allow jcr:versionManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(null, U.adminSession, 2);
 
         // matching ACE -> removed
-        setup = "remove ACL for " + groupPrincipalName + "\n"
+        setup = "remove ACE for " + groupPrincipalName + "\n"
                 + "allow jcr:namespaceManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
@@ -232,13 +232,13 @@ public class RemoveTest {
     @Test
     public void testRemoveByHomePath() throws RepoInitParsingException, RepositoryException {
         // no-matching ACE (restriction mismatch) -> not removed
-        String setup = "remove ACL on home("+U.username+")\n"
+        String setup = "remove ACE on home("+U.username+")\n"
                 + "allow jcr:read for "+U.username+" restriction(rep:itemNames, prop1)\n" +
                 "end";
         U.parseAndExecute(setup);
         assertPolicy(userHomePath, U.adminSession, 2);
         
-        setup = "remove ACL on home("+U.username+")\n"
+        setup = "remove ACE on home("+U.username+")\n"
                 + "allow jcr:read for "+U.username+"\n" +
                 "end";
         U.parseAndExecute(setup);
@@ -247,7 +247,7 @@ public class RemoveTest {
     
     @Test
     public void testRemoveEntryWithRestriction() throws Exception {
-        String setup = "remove ACL for " + groupPrincipalName + "\n"
+        String setup = "remove ACE for " + groupPrincipalName + "\n"
                 + "allow jcr:read on "+path+" restriction(rep:glob, /*/foo/*)\n"
                 + "end";
         U.parseAndExecute(setup);

--- a/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
@@ -76,7 +76,7 @@ public class RemoveTest {
                 + "end\n"
                 + "\n"
                 + "set ACL for " + groupPrincipalName + "\n"
-                + "allow jcr:read on "+path+"\n"
+                + "allow jcr:read on "+path+" restriction(rep:glob,/*/foo/*)\n"
                 + "allow jcr:namespaceManagement on :repository\n"
                 + "allow jcr:read on home(" + U.username + ")\n"
                 + "end";
@@ -147,27 +147,86 @@ public class RemoveTest {
         assertPolicy(userHomePath, U.adminSession, 2);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testRemoveByPath() throws RepoInitParsingException, RepositoryException {
+        // non-matching ACE (path-mismatch) -> not removed (and no exception)
         String setup = "set ACL for " + U.username + "\n"
-                + "remove jcr:read on "+path+"\n"
+                + "remove deny jcr:read on /\n"
                 + "end";
         U.parseAndExecute(setup);
+        assertPolicy(path, U.adminSession, 2);
+
+        // non-matching ACE (privilege-mismatch) -> not removed (and no exception)
+        setup = "set ACL for " + U.username + "\n"
+                + "remove deny jcr:read,jcr:write on "+path+"\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(path, U.adminSession, 2);
+
+        // matching ACE -> removed
+        setup = "set ACL for " + U.username + "\n"
+                + "remove deny jcr:read on "+path+"\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(path, U.adminSession, 1);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testRemoveByPath2() throws RepoInitParsingException, RepositoryException {
+    @Test
+    public void testRemoveByRepository() throws RepoInitParsingException, RepositoryException {
+        // non-matching ACE (allow mismatch) -> not removed (and no exception)
+        String setup = "set repository ACL for " + groupPrincipalName + "\n"
+                + "remove deny jcr:namespaceManagement\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(null, U.adminSession, 2);
+
+        // matching ACE -> removed
+        setup = "set repository ACL for " + groupPrincipalName + "\n"
+                + "remove allow jcr:namespaceManagement\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(null, U.adminSession, 1);
+    }
+
+    @Test
+    public void testRemoveByPrincipalRepositoryPath() throws RepoInitParsingException, RepositoryException {
+        // non-matching ACE (privilege mismatch) -> not removed (and no exception)
         String setup = "set ACL for " + groupPrincipalName + "\n"
-                + "remove jcr:versionManagement on :repository\n"
+                + "remove allow jcr:versionManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
+        assertPolicy(null, U.adminSession, 2);
+
+        // matching ACE -> removed
+        setup = "set ACL for " + groupPrincipalName + "\n"
+                + "remove allow jcr:namespaceManagement on :repository\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(null, U.adminSession, 1);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testRemoveByPrincipal() throws RepoInitParsingException, RepositoryException {
+    @Test
+    public void testRemoveByHomePath() throws RepoInitParsingException, RepositoryException {
+        // no-matching ACE (restriction mismatch) -> not removed
         String setup = "set ACL on home("+U.username+")\n"
-                + "remove jcr:all for "+U.username+"\n" +
+                + "remove allow jcr:read for "+U.username+" restriction(rep:itemNames, prop1)\n" +
                 "end";
         U.parseAndExecute(setup);
+        assertPolicy(userHomePath, U.adminSession, 2);
+        
+        setup = "set ACL on home("+U.username+")\n"
+                + "remove allow jcr:read for "+U.username+"\n" +
+                "end";
+        U.parseAndExecute(setup);
+        assertPolicy(userHomePath, U.adminSession, 1);
+    }
+    
+    @Test
+    public void testRemoveEntryWithRestriction() throws Exception {
+        String setup = "set ACL for " + groupPrincipalName + "\n"
+                + "remove allow jcr:read on "+path+" restriction(rep:glob, /*/foo/*)\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertPolicy(path, U.adminSession, 1);
     }
 }

--- a/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
@@ -147,25 +147,49 @@ public class RemoveTest {
         assertPolicy(userHomePath, U.adminSession, 2);
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testRemoveActionByPath() throws RepoInitParsingException, RepositoryException {
+        String setup = "set ACL for " + U.username + "\n"
+                + "remove jcr:read on "+path+"\n"
+                + "end";
+        U.parseAndExecute(setup);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testRemoveByPath2() throws RepoInitParsingException, RepositoryException {
+        String setup = "set ACL for " + groupPrincipalName + "\n"
+                + "remove jcr:versionManagement on :repository\n"
+                + "end";
+        U.parseAndExecute(setup);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testRemoveActionByPrincipal() throws RepoInitParsingException, RepositoryException {
+        String setup = "set ACL on home("+U.username+")\n"
+                + "remove jcr:all for "+U.username+"\n" +
+                "end";
+        U.parseAndExecute(setup);
+    }
+
     @Test
     public void testRemoveByPath() throws RepoInitParsingException, RepositoryException {
         // non-matching ACE (path-mismatch) -> not removed (and no exception)
-        String setup = "set ACL for " + U.username + "\n"
-                + "remove deny jcr:read on /\n"
+        String setup = "remove ACL for " + U.username + "\n"
+                + "deny jcr:read on /\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(path, U.adminSession, 2);
 
         // non-matching ACE (privilege-mismatch) -> not removed (and no exception)
-        setup = "set ACL for " + U.username + "\n"
-                + "remove deny jcr:read,jcr:write on "+path+"\n"
+        setup = "remove ACL for " + U.username + "\n"
+                + "deny jcr:read,jcr:write on "+path+"\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(path, U.adminSession, 2);
 
         // matching ACE -> removed
-        setup = "set ACL for " + U.username + "\n"
-                + "remove deny jcr:read on "+path+"\n"
+        setup = "remove ACL for " + U.username + "\n"
+                + "deny jcr:read on "+path+"\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(path, U.adminSession, 1);
@@ -174,15 +198,15 @@ public class RemoveTest {
     @Test
     public void testRemoveByRepository() throws RepoInitParsingException, RepositoryException {
         // non-matching ACE (allow mismatch) -> not removed (and no exception)
-        String setup = "set repository ACL for " + groupPrincipalName + "\n"
-                + "remove deny jcr:namespaceManagement\n"
+        String setup = "remove ACL for " + groupPrincipalName + "\n"
+                + "deny jcr:namespaceManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(null, U.adminSession, 2);
 
         // matching ACE -> removed
-        setup = "set repository ACL for " + groupPrincipalName + "\n"
-                + "remove allow jcr:namespaceManagement\n"
+        setup = "remove ACL for " + groupPrincipalName + "\n"
+                + "allow jcr:namespaceManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(null, U.adminSession, 1);
@@ -191,15 +215,15 @@ public class RemoveTest {
     @Test
     public void testRemoveByPrincipalRepositoryPath() throws RepoInitParsingException, RepositoryException {
         // non-matching ACE (privilege mismatch) -> not removed (and no exception)
-        String setup = "set ACL for " + groupPrincipalName + "\n"
-                + "remove allow jcr:versionManagement on :repository\n"
+        String setup = "remove ACL for " + groupPrincipalName + "\n"
+                + "allow jcr:versionManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(null, U.adminSession, 2);
 
         // matching ACE -> removed
-        setup = "set ACL for " + groupPrincipalName + "\n"
-                + "remove allow jcr:namespaceManagement on :repository\n"
+        setup = "remove ACL for " + groupPrincipalName + "\n"
+                + "allow jcr:namespaceManagement on :repository\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(null, U.adminSession, 1);
@@ -208,14 +232,14 @@ public class RemoveTest {
     @Test
     public void testRemoveByHomePath() throws RepoInitParsingException, RepositoryException {
         // no-matching ACE (restriction mismatch) -> not removed
-        String setup = "set ACL on home("+U.username+")\n"
-                + "remove allow jcr:read for "+U.username+" restriction(rep:itemNames, prop1)\n" +
+        String setup = "remove ACL on home("+U.username+")\n"
+                + "allow jcr:read for "+U.username+" restriction(rep:itemNames, prop1)\n" +
                 "end";
         U.parseAndExecute(setup);
         assertPolicy(userHomePath, U.adminSession, 2);
         
-        setup = "set ACL on home("+U.username+")\n"
-                + "remove allow jcr:read for "+U.username+"\n" +
+        setup = "remove ACL on home("+U.username+")\n"
+                + "allow jcr:read for "+U.username+"\n" +
                 "end";
         U.parseAndExecute(setup);
         assertPolicy(userHomePath, U.adminSession, 1);
@@ -223,8 +247,8 @@ public class RemoveTest {
     
     @Test
     public void testRemoveEntryWithRestriction() throws Exception {
-        String setup = "set ACL for " + groupPrincipalName + "\n"
-                + "remove allow jcr:read on "+path+" restriction(rep:glob, /*/foo/*)\n"
+        String setup = "remove ACL for " + groupPrincipalName + "\n"
+                + "allow jcr:read on "+path+" restriction(rep:glob, /*/foo/*)\n"
                 + "end";
         U.parseAndExecute(setup);
         assertPolicy(path, U.adminSession, 1);


### PR DESCRIPTION
@bdelacretaz , @cziegeler , @karlpauls , implementation of the REMOVE of a dedicated ACE which was not supported up to now. i would appreciate if you had time to review it.

NOTE: build will fail unless PR to repoinit.parser is merged. so for the time being this is for illustration of the problem with the existing repo-init language and why i suggest to change it).