### PR TITLE
SLING-8843 repoinit developer mode

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -16,9 +16,9 @@
 # under the License.
 
 log4j.rootLogger=INFO, file
-log4j.appender.file=org.apache.log4j.FileAppender
-log4j.appender.file.File=target/testing.log
+log4j.appender.file=org.apache.log4j.ConsoleAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{dd.MM.yyyy HH:mm:ss} *%-5p* [%t] %c{1}: %m (%F, line %L)\n
+log4j.appender.file.layout.ConversionPattern=%d{dd.MM.yyyy HH:mm:ss:SSS} *%-5p* [%t] %c{1}: %m (%F, line %L)\n
 
 log4j.logger.org.apache.jackrabbit=WARN
+log4j.logger.org.apache.sling.jcr.resource=WARN


### PR DESCRIPTION
when providing the system property
"org.apache.sling.jcr.repoinit.developermode" with the value "true"
repoinit will not throw exception and terminate the startup of the
repository, but instead logs an message pointing this out.
Thus it's easier for a developer to fix the script without the need to
make the repository going first.

To clearly point out potential mis-use (having it configured in
production environments), this log message is written on loglevel ERROR
and also the on startup the "developer mode active" INFO message is
written.