### PR TITLE
SLING-11245 : AclUtil.removePolicies(Session, List<String> paths) will fail if no policy exists...

### DIFF
--- a/src/test/java/org/apache/sling/jcr/repoinit/DeleteAclTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/DeleteAclTest.java
@@ -50,7 +50,9 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class DeleteAclTest {
@@ -94,6 +96,7 @@ public class DeleteAclTest {
         U.parseAndExecute(""
                 + "create path (nt:unstructured) /content\n"
                 + "create path (nt:unstructured) /var\n"
+                + "create path (nt:unstructured) /no/policy\n"
                 + "set ACL for " + U.username + "\n"
                 + "allow jcr:read on /content, /var, home("+userA+")\n"
                 + "allow jcr:namespaceManagement on :repository\n"
@@ -131,9 +134,22 @@ public class DeleteAclTest {
         assertArrayEquals(new AccessControlPolicy[0], acMgr.getPolicies((String) null));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testDeleteAclNonExistingPath() throws Exception {
+        assertFalse(adminSession.nodeExists("/nonExisting"));
         U.parseAndExecute("delete ACL on /nonExisting\n");
+        assertFalse(adminSession.nodeExists("/nonExisting"));
+    }
+
+    @Test
+    public void testDeleteNonExistingAcl() throws Exception {
+        assertTrue(adminSession.nodeExists("/no/policy"));
+        assertArrayEquals(new AccessControlPolicy[0], acMgr.getPolicies("/no/policy"));
+
+        U.parseAndExecute("delete ACL on /no/policy\n");
+        
+        assertTrue(adminSession.nodeExists("/no/policy"));
+        assertArrayEquals(new AccessControlPolicy[0], acMgr.getPolicies("/no/policy"));
     }
 
     @Test

--- a/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
@@ -41,6 +41,7 @@ import javax.jcr.security.AccessControlPolicy;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public class RemoveTest {
@@ -169,6 +170,28 @@ public class RemoveTest {
                 + "remove jcr:all for "+U.username+"\n" +
                 "end";
         U.parseAndExecute(setup);
+    }
+    
+    @Test
+    public void testRemoveByNonExistingPath() throws Exception {
+        String path = "/non/existing";
+        String setup = "remove ACE for " + U.username + "\n"
+                + "deny jcr:read on "+path+"\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertFalse(U.adminSession.nodeExists(path));
+
+        setup = "remove ACE on "+path+"\n"
+                + "deny jcr:read for " + U.username + "\n"
+                + "end";
+        U.parseAndExecute(setup);
+        assertFalse(U.adminSession.nodeExists(path));
+
+        setup = "set ACL on "+path+"\n" +
+                "remove * for "+U.username+"\n" +
+                "end";
+        U.parseAndExecute(setup);
+        assertFalse(U.adminSession.nodeExists(path));
     }
 
     @Test


### PR DESCRIPTION
SLING-11246 : Avoid repeated calls to Session.getAccessControlManager in AclUtil
SLING-11249 : Missing test for removing entries at non-existing path