### PR TITLE
SLING-11293 improve handling of autocreated properties

### DIFF
--- a/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 import javax.jcr.PropertyType;
@@ -229,10 +230,10 @@ public class SetPropertiesTest {
 
         // create the test node
         String name = UUID.randomUUID().toString();
+        String testPath = pathPrefix + name;
         U.getAdminSession()
-            .getNode("/one/two")
+            .getNode(Paths.get(testPath).getParent().toString())
             .addNode(name, "slingtest:sling11293");
-        String testPath = "/one/two/" + name;
         U.assertNodeExists(testPath);
         // verify the initial autocreated property values
         U.assertSVPropertyExists(testPath, "singleVal", vf.createValue("autocreated value"));

--- a/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
@@ -354,7 +354,7 @@ public class SetPropertiesTest {
 
     protected void registerSling11293NodeType()
             throws RepositoryException, RepoInitParsingException, NoSuchNodeTypeException {
-        final String registerAndCreateTestPath =
+        final String registerNodeTypes =
                 "register nodetypes\n" +
                 "<<===\n" +
                 "<< <slingtest='http://sling.apache.org/ns/test/repoinit-it/v1.0'>\n" +
@@ -370,9 +370,11 @@ public class SetPropertiesTest {
                 "<<    - multiVal (String) = 'autocreated value1', 'autocreated value2'\n" +
                 "<<       multiple autocreated\n" +
                 "===>>";
-        U.parseAndExecute(registerAndCreateTestPath);
+        U.parseAndExecute(registerNodeTypes);
         NodeType nodeType = U.getAdminSession().getWorkspace().getNodeTypeManager().getNodeType("slingtest:sling11293");
         assertNotNull(nodeType);
+        NodeType mixinType = U.getAdminSession().getWorkspace().getNodeTypeManager().getNodeType("slingtest:sling11293mixin");
+        assertNotNull(mixinType);
     }
 
     /**

--- a/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/SetPropertiesTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.UUID;
 
+import javax.jcr.Node;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
@@ -225,15 +226,36 @@ public class SetPropertiesTest {
      * SLING-11293 "set default properties" instruction to change autocreated property value
      */
     @Test
-    public void setAutocreatedDefaultProperties() throws Exception {
+    public void setAutocreatedDefaultPropertiesFromPrimaryType() throws Exception {
         registerSling11293NodeType();
 
         // create the test node
         String name = UUID.randomUUID().toString();
         String testPath = pathPrefix + name;
-        U.getAdminSession()
-            .getNode(Paths.get(testPath).getParent().toString())
-            .addNode(name, "slingtest:sling11293");
+        Node parentNode = U.getAdminSession()
+            .getNode(Paths.get(testPath).getParent().toString());
+        parentNode.addNode(name, "slingtest:sling11293");
+        changeAutocreatedDefaultProperties(testPath);
+    }
+
+    /**
+     * SLING-11293 "set default properties" instruction to change autocreated property value
+     */
+    @Test
+    public void setAutocreatedDefaultPropertiesFromMixinType() throws Exception {
+        registerSling11293NodeType();
+
+        // create the test node
+        String name = UUID.randomUUID().toString();
+        String testPath = pathPrefix + name;
+        Node parentNode = U.getAdminSession()
+            .getNode(Paths.get(testPath).getParent().toString());
+        parentNode.addNode(name).addMixin("slingtest:sling11293mixin");
+        changeAutocreatedDefaultProperties(testPath);
+    }
+
+    protected void changeAutocreatedDefaultProperties(String testPath)
+            throws RepositoryException, RepoInitParsingException {
         U.assertNodeExists(testPath);
         // verify the initial autocreated property values
         U.assertSVPropertyExists(testPath, "singleVal", vf.createValue("autocreated value"));
@@ -337,6 +359,12 @@ public class SetPropertiesTest {
                 "<<===\n" +
                 "<< <slingtest='http://sling.apache.org/ns/test/repoinit-it/v1.0'>\n" +
                 "<< [slingtest:sling11293] > nt:unstructured\n" +
+                "<<    - singleVal (String) = 'autocreated value'\n" +
+                "<<       autocreated\n" +
+                "<<    - multiVal (String) = 'autocreated value1', 'autocreated value2'\n" +
+                "<<       multiple autocreated\n" +
+                "<< [slingtest:sling11293mixin]\n" +
+                "<<    mixin\n" +
                 "<<    - singleVal (String) = 'autocreated value'\n" +
                 "<<       autocreated\n" +
                 "<<    - multiVal (String) = 'autocreated value1', 'autocreated value2'\n" +


### PR DESCRIPTION
allow set default properties instruction to change autocreated property values if they are unchanged from the initial value