### PR TITLE
SLING-11434 Cleanup compiler and sonar warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,5 +304,10 @@
             <version>2.6</version>
             <scope>test</scope>
         </dependency>
+       <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/DoNothingVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/DoNothingVisitor.java
@@ -51,9 +51,9 @@ import org.slf4j.LoggerFactory;
 class DoNothingVisitor implements OperationVisitor {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
-    
+
     protected final Session session;
-    
+
     /** Create a visitor using the supplied JCR Session.
      * @param s must have sufficient rights to create users
      *      and set ACLs.
@@ -61,15 +61,15 @@ class DoNothingVisitor implements OperationVisitor {
     protected DoNothingVisitor(Session s) {
         session = s;
     }
-    
+
     protected void report(Exception e, String message) {
         throw new RepoInitException(message, e);
     }
-    
+
     protected void report(String message) {
         throw new RepoInitException(message);
     }
-    
+
     protected static String excerpt(String s, int maxLength) {
         if(s.length() < maxLength) {
             return s;
@@ -77,97 +77,119 @@ class DoNothingVisitor implements OperationVisitor {
             return s.substring(0, maxLength -1) + "...";
         }
     }
-    
+
     @Override
     public void visitCreateServiceUser(CreateServiceUser s) {
+        // no-op
     }
 
     @Override
     public void visitDeleteServiceUser(DeleteServiceUser s) {
+        // no-op
     }
 
     @Override
     public void visitCreateUser(CreateUser cu) {
+        // no-op
     }
 
     @Override
     public void visitDeleteUser(DeleteUser u) {
+        // no-op
     }
-    
+
     @Override
     public void visitSetAclPrincipal(SetAclPrincipals s) {
-     }
+        // no-op
+    }
 
     @Override
     public void visitSetAclPaths(SetAclPaths s) {
+        // no-op
     }
 
     @Override
     public void visitSetAclPrincipalBased(SetAclPrincipalBased operation) {
+        // no-op
     }
 
     @Override
     public void visitRemoveAcePrincipal(RemoveAcePrincipals s) {
+        // no-op
     }
 
     @Override
     public void visitRemoveAcePaths(RemoveAcePaths s) {
+        // no-op
     }
 
     @Override
     public void visitRemoveAcePrincipalBased(RemoveAcePrincipalBased s) {
+        // no-op
     }
 
     @Override
     public void visitDeleteAclPrincipals(DeleteAclPrincipals s) {
+        // no-op
     }
 
     @Override
     public void visitDeleteAclPaths(DeleteAclPaths s) {
+        // no-op
     }
 
     @Override
     public void visitDeleteAclPrincipalBased(DeleteAclPrincipalBased s) {
+        // no-op
     }
 
     @Override
     public void visitCreatePath(CreatePath cp) {
+        // no-op
     }
 
     @Override
     public void visitRegisterNamespace(RegisterNamespace rn) {
+        // no-op
     }
 
     @Override
     public void visitRegisterNodetypes(RegisterNodetypes rn) {
+        // no-op
     }
 
     @Override
     public void visitRegisterPrivilege(RegisterPrivilege rp) {
-
+        // no-op
     }
 
     @Override
     public void visitDisableServiceUser(DisableServiceUser dsu) {
+        // no-op
     }
 
     @Override
     public void visitCreateGroup(CreateGroup g) {
+        // no-op
     }
 
     @Override
     public void visitDeleteGroup(DeleteGroup g) {
+        // no-op
     }
 
     @Override
     public void visitAddGroupMembers(AddGroupMembers am) {
+        // no-op
     }
 
     @Override
     public void visitRemoveGroupMembers(RemoveGroupMembers rm) {
+        // no-op
     }
 
     @Override
     public void visitSetProperties(SetProperties sp) {
+        // no-op
     }
 }

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/NodetypesVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/NodetypesVisitor.java
@@ -40,7 +40,9 @@ class NodetypesVisitor extends DoNothingVisitor {
     @Override
     public void visitRegisterNodetypes(RegisterNodetypes rn) {
         try {
-            log.info("Registering nodetypes from {}", excerpt(rn.getCndStatements(), 100));
+            if (log.isInfoEnabled()) {
+                log.info("Registering nodetypes from {}", excerpt(rn.getCndStatements(), 100));
+            }
             CndImporter.registerNodeTypes(new StringReader(rn.getCndStatements()), session);
         } catch(Exception e) {
             report(e, "Unable to register nodetypes from " + rn);

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeVisitor.java
@@ -34,17 +34,15 @@ public class PrivilegeVisitor extends DoNothingVisitor {
         try {
             Privilege priv = ((JackrabbitWorkspace) session.getWorkspace()).getPrivilegeManager().getPrivilege(rp.getPrivilegeName());
             log.info("Privilege {} already exists: {}, no changes made.", rp.getPrivilegeName(), priv);
-        } catch (Exception e) {
-            if (e instanceof AccessControlException) {
-                try {
-                    ((JackrabbitWorkspace) session.getWorkspace()).getPrivilegeManager()
-                        .registerPrivilege(rp.getPrivilegeName(), rp.isAbstract(), rp.getDeclaredAggregateNames().toArray(new String[0]));
-                } catch (Exception ex) {
-                    report(ex, "Unable to register privilege from: " + rp);
-                }
-            } else {
-                report(e, "Unable to register privilege from: " + rp);
+        } catch (AccessControlException ace) {
+            try {
+                ((JackrabbitWorkspace) session.getWorkspace()).getPrivilegeManager()
+                    .registerPrivilege(rp.getPrivilegeName(), rp.isAbstract(), rp.getDeclaredAggregateNames().toArray(new String[0]));
+            } catch (Exception ex) {
+                report(ex, "Unable to register privilege from: " + rp);
             }
+        } catch (Exception e) {
+            report(e, "Unable to register privilege from: " + rp);
         }
     }
 }

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/RepoInitException.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/RepoInitException.java
@@ -22,11 +22,12 @@ package org.apache.sling.jcr.repoinit.impl;
  *
  */
 public class RepoInitException extends RuntimeException {
-    
+    private static final long serialVersionUID = 1526164337560554094L;
+
     public RepoInitException(String msg, Exception e) {
         super(msg, e);
     }
-    
+
     public RepoInitException(String msg) {
         super(msg);
     }

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/RepositoryInitializerFactory.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/RepositoryInitializerFactory.java
@@ -88,7 +88,7 @@ public class RepositoryInitializerFactory implements SlingRepositoryInitializer 
     @Activate
     public void activate(final RepositoryInitializerFactory.Config config) {
         this.config = config;
-        log.debug("Activated: {}", this.toString());
+        log.debug("Activated: {}", this);
     }
 
     @Override
@@ -104,6 +104,7 @@ public class RepositoryInitializerFactory implements SlingRepositoryInitializer 
            || (config.scripts() != null && config.scripts().length > 0 )) {
 
             // loginAdministrative is ok here, definitely an admin operation
+            @SuppressWarnings("deprecation")
             final Session s = repo.loginAdministrative(null);
             try {
                 if ( config.references() != null ) {
@@ -113,7 +114,10 @@ public class RepositoryInitializerFactory implements SlingRepositoryInitializer 
                             continue;
                         }
                         final String repoinitText = p.getRepoinitText("raw:" + reference);
-                        final List<Operation> ops = parser.parse(new StringReader(repoinitText));
+                        final List<Operation> ops;
+                        try (StringReader sr = new StringReader(repoinitText)) {
+                            ops = parser.parse(sr);
+                        }
                         String msg = String.format("Executing %s repoinit operations", ops.size());
                         log.info(msg);
                         applyOperations(s,ops,msg);
@@ -124,7 +128,10 @@ public class RepositoryInitializerFactory implements SlingRepositoryInitializer 
                         if(script == null || script.trim().length() == 0) {
                             continue;
                         }
-                        final List<Operation> ops = parser.parse(new StringReader(script));
+                        final List<Operation> ops;
+                        try (StringReader sr = new StringReader(script)) {
+                            ops = parser.parse(sr);
+                        }
                         String msg = String.format("Executing %s repoinit operations", ops.size());
                         log.info(msg);
                         applyOperations(s,ops,msg);

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/UserUtil.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/UserUtil.java
@@ -32,6 +32,10 @@ import java.security.Principal;
 /** Utilities for User management */
 public class UserUtil {
 
+    private UserUtil() {
+        // private constructor to hide the implicit public one
+    }
+
     static class SameNamePrincipal implements Principal {
 
         private final String name;

--- a/src/test/java/org/apache/sling/jcr/repoinit/CreatePathsTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/CreatePathsTest.java
@@ -30,6 +30,7 @@ import javax.jcr.ValueFactory;
 
 import org.apache.sling.commons.testing.jcr.RepositoryUtil;
 import org.apache.sling.jcr.repoinit.impl.TestUtil;
+import org.apache.sling.repoinit.parser.RepoInitParsingException;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Before;
@@ -54,34 +55,34 @@ public class CreatePathsTest {
         RepositoryUtil.registerSlingNodeTypes(U.adminSession);
     }
 
-    @Test
-    public void createSimplePath() throws Exception {
-        final String path = "/one/two/three";
+    /**
+     * @param path the path to create
+     */
+    protected void assertSimplePath(final String path) throws RepositoryException, RepoInitParsingException {
         U.parseAndExecute("create path " + path);
         U.assertNodeExists(path);
+    }
+
+    @Test
+    public void createSimplePath() throws Exception {
+        assertSimplePath("/one/two/three");
     }
 
     @Test
     public void createSimplePathWithNamespace() throws Exception {
-        final String path = "/rep:policy/one";
-        U.parseAndExecute("create path " + path);
-        U.assertNodeExists(path);
+        assertSimplePath("/rep:policy/one");
     }
 
     @Test
     public void createSimplePathWithAtSymbol() throws Exception {
-        final String path = "/one/@two/three";
-        U.parseAndExecute("create path " + path);
-        U.assertNodeExists(path);
+        assertSimplePath("/one/@two/three");
     }
 
     @Test
     public void createSimplePathWithPlusSymbol() throws Exception {
-        final String path = "/one/+two/three";
-        U.parseAndExecute("create path " + path);
-        U.assertNodeExists(path);
+        assertSimplePath("/one/+two/three");
     }
-    
+
     @Test
     public void createPathWithTypes() throws Exception {
         final String path = "/four/five(sling:Folder)/six(nt:folder)";
@@ -90,7 +91,7 @@ public class CreatePathsTest {
         U.assertNodeExists("/four/five", "sling:Folder");
         U.assertNodeExists("/four/five/six", "nt:folder");
     }
-    
+
     @Test
     public void createPathWithSpecificDefaultType() throws Exception {
         final String path = "/seven/eight(nt:unstructured)/nine";
@@ -99,7 +100,7 @@ public class CreatePathsTest {
         U.assertNodeExists("/seven/eight", "nt:unstructured");
         U.assertNodeExists("/seven/eight/nine", "sling:Folder");
     }
-    
+
     @Test
     public void createPathWithJcrDefaultType() throws Exception {
         final String path = "/ten/eleven(sling:Folder)/twelve";

--- a/src/test/java/org/apache/sling/jcr/repoinit/CreateServiceUsersTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/CreateServiceUsersTest.java
@@ -47,7 +47,7 @@ public class CreateServiceUsersTest {
     private String userId;
     private TestUtil U;
 
-    private final List<String> toRemove = new ArrayList();
+    private final List<String> toRemove = new ArrayList<>();
     
     @Before
     public void setup() throws RepositoryException {

--- a/src/test/java/org/apache/sling/jcr/repoinit/EveryoneTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/EveryoneTest.java
@@ -25,6 +25,7 @@ import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Test.None;
 
 public class EveryoneTest {
 
@@ -40,7 +41,7 @@ public class EveryoneTest {
         testUtil.parseAndExecute(statement);
     }
 
-    @Test
+    @Test(expected = None.class)
     public void setAclForEveryone() throws RepositoryException, RepoInitParsingException {
         final String statement = "set ACL for everyone\n  allow jcr:read on /content\nend";
         testUtil.parseAndExecute(statement);

--- a/src/test/java/org/apache/sling/jcr/repoinit/GeneralAclTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/GeneralAclTest.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Test.None;
 
 /** Various ACL-related tests */
 public class GeneralAclTest {
@@ -365,9 +366,8 @@ public class GeneralAclTest {
      */
     private void verifyCanRead(Session userSession, String relativePath, boolean successExpected) {
         final String path = "/" + relativePath;
-        Node n = null;
         try {
-            n = userSession.getNode(path);
+            userSession.getNode(path);
             assertTrue("Not expecting " + path + " to be readable but it was successfully read", successExpected);
         } catch(RepositoryException notReadable) {
             assertFalse("Expecting " + path + " to be readable but could not read it", successExpected);
@@ -705,7 +705,7 @@ public class GeneralAclTest {
     }
 
 
-    @Test
+    @Test(expected = None.class)
     public void emptyRestrictionTest() throws Exception {
         final String aclSetup =
                 "set ACL for " + U.username + "\n"

--- a/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
@@ -50,6 +50,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Test.None;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -481,7 +482,7 @@ public class PrincipalBasedAclTest {
         assertEquals(2, pacl.size());
     }
 
-    @Test
+    @Test(expected = None.class)
     public void  principalAclNotAvailable() throws Exception {
         try {
             // create service user outside of supported tree for principal-based access control
@@ -693,7 +694,7 @@ public class PrincipalBasedAclTest {
         }
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testRemoveNoExistingPolicy() throws Exception {
         String setup = "remove principal ACE for " + U.username + "\n"
                 + "allow jcr:read on " + path + "\n"
@@ -887,7 +888,7 @@ public class PrincipalBasedAclTest {
         assertPolicy(getPrincipal(U.username), U.adminSession, 2);
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testRemoveAllPrincipalMismatch() throws Exception {
         String setup = "set principal ACL for " + U.username + "\n"
                 + "allow jcr:write on "+path+"\n"

--- a/src/test/java/org/apache/sling/jcr/repoinit/RegisterNodetypesTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RegisterNodetypesTest.java
@@ -30,19 +30,20 @@ import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Test.None;
 
 /** Test register nodetypes statements. Also registers a namespace */
 public class RegisterNodetypesTest {
 
     @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
-    
+
     private TestUtil U;
-    
+
     private static final String TEST_ID = UUID.randomUUID().toString();
     private static final String NS_PREFIX = RegisterNodetypesTest.class.getSimpleName();
     private static final String NS_URI = "uri:" + NS_PREFIX + ":" + TEST_ID;
-    
+
     @Before
     public void setup() throws RepositoryException, RepoInitParsingException {
         U = new TestUtil(context);
@@ -55,8 +56,8 @@ public class RegisterNodetypesTest {
         final NamespaceRegistry ns = U.getAdminSession().getWorkspace().getNamespaceRegistry();
         assertEquals(NS_URI, ns.getURI(NS_PREFIX));
     }
-    
-    @Test
+
+    @Test(expected = None.class)
     public void fooNodetypeRegistered() throws Exception {
         U.getAdminSession().getRootNode().addNode("test_" + TEST_ID, NS_PREFIX + ":foo");
     }

--- a/src/test/java/org/apache/sling/jcr/repoinit/RegisterPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RegisterPrivilegeTest.java
@@ -57,7 +57,7 @@ public class RegisterPrivilegeTest {
         Privilege privilege = ((JackrabbitWorkspace) U.getAdminSession().getWorkspace()).getPrivilegeManager().getPrivilege("withoutabstract_withoutaggregates1");
 
         assertFalse(privilege.isAbstract());
-        assertTrue(privilege.getDeclaredAggregatePrivileges().length == 0);
+        assertEquals(0, privilege.getDeclaredAggregatePrivileges().length);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class RegisterPrivilegeTest {
         Privilege privilege = ((JackrabbitWorkspace) U.getAdminSession().getWorkspace()).getPrivilegeManager().getPrivilege("withabstract_withoutaggregates");
 
         assertTrue(privilege.isAbstract());
-        assertTrue(privilege.getDeclaredAggregatePrivileges().length == 0);
+        assertEquals(0, privilege.getDeclaredAggregatePrivileges().length);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class RegisterPrivilegeTest {
         Privilege privilege = ((JackrabbitWorkspace) U.getAdminSession().getWorkspace()).getPrivilegeManager().getPrivilege("withoutabstract_withaggregates");
 
         assertFalse(privilege.isAbstract());
-        assertTrue(privilege.getDeclaredAggregatePrivileges().length == 2);
+        assertEquals(2, privilege.getDeclaredAggregatePrivileges().length);
 
         Set<String> names = new HashSet<>();
         for (Privilege p : privilege.getDeclaredAggregatePrivileges()) {
@@ -87,7 +87,7 @@ public class RegisterPrivilegeTest {
         Privilege privilege = ((JackrabbitWorkspace) U.getAdminSession().getWorkspace()).getPrivilegeManager().getPrivilege("withabstract_withaggregates");
 
         assertTrue(privilege.isAbstract());
-        assertTrue(privilege.getDeclaredAggregatePrivileges().length == 2);
+        assertEquals(2, privilege.getDeclaredAggregatePrivileges().length);
 
         Set<String> names = new HashSet<>();
         for (Privilege p : privilege.getDeclaredAggregatePrivileges()) {

--- a/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RemoveTest.java
@@ -16,10 +16,20 @@
  */
 package org.apache.sling.jcr.repoinit;
 
-import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.util.UUID;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.AccessControlPolicy;
+
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
-import org.apache.sling.jcr.repoinit.impl.AclUtil;
 import org.apache.sling.jcr.repoinit.impl.TestUtil;
 import org.apache.sling.jcr.repoinit.impl.UserUtil;
 import org.apache.sling.repoinit.parser.RepoInitParsingException;
@@ -31,18 +41,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.security.AccessControlList;
-import javax.jcr.security.AccessControlPolicy;
-
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 
 public class RemoveTest {
 

--- a/src/test/java/org/apache/sling/jcr/repoinit/RepositoryInitializerTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/RepositoryInitializerTest.java
@@ -72,18 +72,18 @@ public class RepositoryInitializerTest {
         final List<Object []> result = new ArrayList<Object[]>();
 
         // Realistic cases
-        result.add(new Object[] { "Using provisioning model", "SECTION_" + UUID.randomUUID(), TextFormat.model.toString(), true, true, null });
-        result.add(new Object[] { "Default value of model section config", null, TextFormat.model.toString(), true, true, null });
-        result.add(new Object[] { "Raw repoinit/empty section", "", TextFormat.raw.toString(), false, true, null });
-        result.add(new Object[] { "Raw repoinit/ignored section name", "IGNORED_SectionName", TextFormat.raw.toString(), false, true, null });
+        result.add(new Object[] { "Using provisioning model", "SECTION_" + UUID.randomUUID(), TextFormat.MODEL.toString(), true, true, null });
+        result.add(new Object[] { "Default value of model section config", null, TextFormat.MODEL.toString(), true, true, null });
+        result.add(new Object[] { "Raw repoinit/empty section", "", TextFormat.RAW.toString(), false, true, null });
+        result.add(new Object[] { "Raw repoinit/ignored section name", "IGNORED_SectionName", TextFormat.RAW.toString(), false, true, null });
 
         // Edge and failure cases
-        result.add(new Object[] { "All empty, just setup + parsing", "", TextFormat.raw.toString(), false, false, null });
+        result.add(new Object[] { "All empty, just setup + parsing", "", TextFormat.RAW.toString(), false, false, null });
         result.add(new Object[] { "Raw repoinit/null format", null, null, true, false, RepoInitParsingException.class });
         result.add(new Object[] { "With model/null format", null, null, false, false, RuntimeException.class });
         result.add(new Object[] { "Invalid format", null, "invalidFormat", false, false, RuntimeException.class });
-        result.add(new Object[] { "Empty model section", "", TextFormat.model.toString(), false, false, IllegalArgumentException.class });
-        result.add(new Object[] { "Null model section", null, TextFormat.model.toString(), false, false, IOException.class });
+        result.add(new Object[] { "Empty model section", "", TextFormat.MODEL.toString(), false, false, IllegalArgumentException.class });
+        result.add(new Object[] { "Null model section", null, TextFormat.MODEL.toString(), false, false, IOException.class });
 
         return result;
     }
@@ -111,7 +111,7 @@ public class RepositoryInitializerTest {
         U = new TestUtil(context);
 
         final String ref;
-        if(TextFormat.model.toString().equals(textFormat)) {
+        if(TextFormat.MODEL.toString().equals(textFormat)) {
             if(modelSection != null) {
                 ref = "model@" + modelSection + ":" + url;
             } else {

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/RepoinitReferenceTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/RepoinitReferenceTest.java
@@ -38,20 +38,20 @@ public class RepoinitReferenceTest {
         final List<Object []> result = new ArrayList<Object[]>();
         
         // Valid references
-        result.add(new Object[] { "model@foo:uri:1234", TextFormat.model, "foo", "uri:1234", null }); 
-        result.add(new Object[] { "model:uri:2345", TextFormat.model, "repoinit", "uri:2345", null }); 
-        result.add(new Object[] { "raw:uri:4567", TextFormat.raw , null, "uri:4567", null }); 
-        result.add(new Object[] { "raw:uri@5678", TextFormat.raw, null, "uri@5678", null });
+        result.add(new Object[] { "model@foo:uri:1234", TextFormat.MODEL, "foo", "uri:1234", null }); 
+        result.add(new Object[] { "model:uri:2345", TextFormat.MODEL, "repoinit", "uri:2345", null }); 
+        result.add(new Object[] { "raw:uri:4567", TextFormat.RAW , null, "uri:4567", null }); 
+        result.add(new Object[] { "raw:uri@5678", TextFormat.RAW, null, "uri@5678", null });
 
         // Invalid references
         result.add(new Object[] { "model@foo", null, null, null, IllegalArgumentException.class });
-        result.add(new Object[] { "model#foo:url", TextFormat.model, "repoinit", "url", IllegalArgumentException.class });
+        result.add(new Object[] { "model#foo:url", TextFormat.MODEL, "repoinit", "url", IllegalArgumentException.class });
         result.add(new Object[] { "", null, null, null, IllegalArgumentException.class });
         result.add(new Object[] { null, null, null, null, IllegalArgumentException.class });
         result.add(new Object[] { "foo:url", null, null, null, IllegalArgumentException.class });
         
         // foo is ignored, by design
-        result.add(new Object[] { "raw@foo:url", TextFormat.raw, null, "url", null });
+        result.add(new Object[] { "raw@foo:url", TextFormat.RAW, null, "url", null });
         
         return result;
     }

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
@@ -16,6 +16,16 @@
  */
 package org.apache.sling.jcr.repoinit.it;
 
+import static org.apache.sling.testing.paxexam.SlingOptions.awaitility;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingQuickstartOakTar;
+import static org.apache.sling.testing.paxexam.SlingOptions.versionResolver;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.vmOption;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
+
 import javax.inject.Inject;
 import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
@@ -29,15 +39,6 @@ import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.sling.testing.paxexam.SlingOptions.slingQuickstartOakTar;
-import static org.apache.sling.testing.paxexam.SlingOptions.versionResolver;
-import static org.ops4j.pax.exam.CoreOptions.composite;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-import static org.ops4j.pax.exam.CoreOptions.vmOption;
-import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
 
 public abstract class RepoInitTestSupport extends TestSupport {
 
@@ -62,6 +63,7 @@ public abstract class RepoInitTestSupport extends TestSupport {
                 testBundle("bundle.filename"),
                 mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.repoinit.parser").versionAsInProject(),
                 junitBundles(),
+                awaitility(),
                 newConfiguration("org.apache.sling.jcr.base.internal.LoginAdminWhitelist")
                     .put("whitelist.bundles.regexp", "^PAXEXAM.*$")
                     .asOption()

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTextIT.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTextIT.java
@@ -36,6 +36,7 @@ import org.apache.sling.jcr.repoinit.JcrRepoInitOpsProcessor;
 import org.apache.sling.repoinit.parser.RepoInitParser;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Test.None;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
@@ -130,7 +131,7 @@ public class RepoInitTextIT extends RepoInitTestSupport {
         };
     }
 
-    @Test
+    @Test(expected = None.class)
     public void namespaceAndCndRegistered() throws Exception {
         final String nodeName = "ns-" + UUID.randomUUID();
         session.getRootNode().addNode(nodeName, "slingtest:unstructured");


### PR DESCRIPTION
When opening the org.apache.sling.jcr.repoinit project in eclipse it shows warnings about java problems and problems reported by sonarlint.

Expected:
Resolve as many of these as possible to reduce the noise so any new problems will be easier to see.