### PR TITLE
SLING-12642 update dependencies - part 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
   <properties>
     <jackrabbit.version>2.18.2</jackrabbit.version>
-    <oak.version>1.22.10</oak.version>
+    <oak.version>1.44.0</oak.version>
     <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
     <!-- To debug the pax process, override this with -D -->
     <pax.vm.options>-Xmx512M</pax.vm.options>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-            <version>3.0.0-1.16.0</version>
+            <version>3.1.10-1.44.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -197,8 +197,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-api</artifactId>
-            <version>${jackrabbit.version}</version>
+            <artifactId>oak-jackrabbit-api</artifactId>
+            <version>${oak.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -259,6 +259,11 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.provisioning.model</artifactId>
             <version>1.8.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,16 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>3.4.10</version>
+            <version>3.5.2</version>
             <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.jackrabbit</groupId><artifactId>oak-jcr</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.jackrabbit</groupId><artifactId>oak-jackrabbit-api</artifactId>
+				</exclusion>
+			</exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
@@ -29,6 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.ModifiableCompositeOption;
 import org.ops4j.pax.exam.util.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,67 +55,53 @@ public abstract class RepoInitTestSupport extends TestSupport {
     protected static final Logger log = LoggerFactory.getLogger(RepoInitTestSupport.class.getName());
 
     final String repositoriesURL = "https://repo1.maven.org/maven2@id=central";
-    
-    // artifact ID of all oak bundles
+
+    private static final String JR_GID = "org.apache.jackrabbit";
+
+    // artifact ID of all relevant oak bundles
     private static final String[] OAK_BUNDLES = new String[] {"oak-api","oak-blob",
             "oak-blob-plugins","oak-commons","oak-core","oak-core-spi","oak-jcr",
             "oak-lucene","oak-query-spi","oak-security-spi","oak-segment-tar","oak-store-composite",
             "oak-store-document","oak-store-spi", "oak-jackrabbit-api"};
-    
+    private static final String TARGET_OAK_VERSION = "1.44.0";
+
     private static final String[] JACKRABBIT_2x_BUNDLES = new String[] {"jackrabbit-data","jackrabbit-jcr-commons",
             "jackrabbit-jcr-rmi","jackrabbit-spi-commons","jackrabbit-spi","jackrabbit-webdav"};
-  
+    private static final String TARGET_JACKRABBIT_VERSION = "2.22.0";
+
     @Inject
     private SlingRepository repository;
 
     @Configuration
     public Option[] configuration() {
-        
-        updateOakVersion("1.44.0");
-        Collection<Option> nonExistingJackrabbitBundles = updateJackrabbit("2.22.0");
-        SlingOptions.versionResolver.setVersion("org.apache.sling", "org.apache.sling.jcr.oak.server", "1.2.10");
+
+        // overwrite provided versions
+        Collection<Option> nonExistingJackrabbitBundles = updateRepositoryBundleVersions();
         SlingOptions.versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.repoinit.parser");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.commons.metrics");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.commons", "commons-lang3"); // for the metrics
+
         return options(composite(
                         super.baseConfiguration(),
                         vmOption(System.getProperty("pax.vm.options")),
                         slingQuickstart(),
+                        junitBundles(),
+                        SlingOptions.logback(),
+                        systemProperty("logback.configurationFile")
+                            .value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback-it.xml"),
+                        awaitility(),
                         testBundle("bundle.filename"),
+                        newConfiguration("org.apache.sling.jcr.base.internal.LoginAdminWhitelist")
+                            .put("whitelist.bundles.regexp", "^PAXEXAM.*$")
+                            .asOption(),
                         mavenBundle()
                                 .groupId("org.apache.sling")
                                 .artifactId("org.apache.sling.repoinit.parser")
                                 .versionAsInProject(),
-                        mavenBundle()
-                            .groupId("org.apache.jackrabbit")
-                            .artifactId("oak-jackrabbit-api")
-                            .versionAsInProject(),
-                        mavenBundle()
-                            .groupId("org.apache.jackrabbit")
-                            .artifactId("oak-store-spi")
-                            .versionAsInProject(),
-                        mavenBundle()
-                            .groupId("commons-codec")
-                            .artifactId("commons-codec")
-                            .version("1.14"),
-                        mavenBundle()
-                            .groupId("commons-io")
-                            .artifactId("commons-io")
-                            .version("2.11.0"),
-                        mavenBundle()
-                            .groupId("org.apache.tika")
-                            .artifactId("tika-core")
-                            .version("1.24.1"),
-                        SlingOptions.logback(),
-                        systemProperty("logback.configurationFile").value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback-it.xml"),
-                        junitBundles(),
-                        awaitility(),
-                        newConfiguration("org.apache.sling.jcr.base.internal.LoginAdminWhitelist")
-                                .put("whitelist.bundles.regexp", "^PAXEXAM.*$")
-                                .asOption())
+                        bundlesForNewerRepository()
+                        )
                 .add(additionalOptions())
                 .remove(nonExistingJackrabbitBundles)
-                .remove(mavenBundle().groupId("org.apache.jackrabbit").artifactId("jackrabbit-api").version(versionResolver))
                 .remove(
                         // remove our bundle under test to avoid duplication
                         mavenBundle()
@@ -123,34 +110,49 @@ public abstract class RepoInitTestSupport extends TestSupport {
                                 .version(versionResolver)));
     }
 
-    protected void updateOakVersion(String defaultVersion) {
+    /**
+     * Update the version number of all relevant bundles to run a newer Oak/Jackrabbit repository; in case that
+     * bundle does not exist in the requested version, it is ignored and added to collection returned.
+     * @return the list of bundles which must be removed from the list of bundles.
+     */
+    private static Collection<Option> updateRepositoryBundleVersions() {
+        SlingOptions.versionResolver.setVersion("org.apache.sling", "org.apache.sling.jcr.oak.server", "1.2.10");
         for (int i=0;i< OAK_BUNDLES.length;i++) {
             try {
-                SlingOptions.versionResolver.setVersionFromProject("org.apache.jackrabbit", OAK_BUNDLES[i]);
+                SlingOptions.versionResolver.setVersionFromProject(JR_GID, OAK_BUNDLES[i]);
             } catch (IllegalArgumentException e) {
                 // the version is not explicitly listed in the pom, so use the provided default version
-                SlingOptions.versionResolver.setVersion("org.apache.jackrabbit", OAK_BUNDLES[i], defaultVersion);
+                versionResolver.setVersion(JR_GID, OAK_BUNDLES[i], TARGET_OAK_VERSION);
             }
         }
-    }
-    
-    protected Collection<Option> updateJackrabbit(String version) {
         Collection<Option> nonExistingBundles = new HashSet<>();
         for (int i=0;i< JACKRABBIT_2x_BUNDLES.length;i++) {
             Option existingBundle = null;
             try {
                 String artifactId=JACKRABBIT_2x_BUNDLES[i];
-                existingBundle = mavenBundle().groupId("org.apache.jackrabbit").artifactId(artifactId).versionAsInProject();
-                SlingOptions.versionResolver.setVersion("org.apache.jackrabbit", artifactId, version);
+                existingBundle = mavenBundle().groupId(JR_GID).artifactId(artifactId).versionAsInProject();
+                SlingOptions.versionResolver.setVersion(JR_GID, artifactId, TARGET_JACKRABBIT_VERSION);
             } catch (IllegalArgumentException e) {
                 nonExistingBundles.add(existingBundle);
-                
             }
         }
         return nonExistingBundles;
     }
-    
-    
+
+    /**
+     * add relevant bundles which are required to run the newer repository version
+     * @return
+     */
+    private static ModifiableCompositeOption bundlesForNewerRepository() {
+        return composite(
+                mavenBundle().groupId(JR_GID).artifactId("oak-jackrabbit-api").version(SlingOptions.versionResolver),
+                mavenBundle().groupId(JR_GID).artifactId("oak-store-spi").version(SlingOptions.versionResolver),
+                mavenBundle().groupId("commons-codec").artifactId("commons-codec").version("1.14"),
+                mavenBundle().groupId("commons-io").artifactId("commons-io").version("2.11.0"),
+                mavenBundle().groupId("org.apache.tika").artifactId("tika-core").version("1.24.1"),
+                mavenBundle().groupId(JR_GID).artifactId("jackrabbit-api").version(versionResolver)
+                );
+    }
     
     protected Option[] additionalOptions() {
         return new Option[] {};

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
@@ -29,6 +29,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.SystemPropertyOption;
+import org.ops4j.pax.exam.util.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +42,7 @@ import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.CoreOptions.vmOption;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
 
 public abstract class RepoInitTestSupport extends TestSupport {
@@ -72,6 +75,8 @@ public abstract class RepoInitTestSupport extends TestSupport {
                             .groupId("org.apache.jackrabbit")
                             .artifactId("oak-jackrabbit-api")
                             .versionAsInProject(),
+                        SlingOptions.logback(),
+                        systemProperty("logback.configurationFile").value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback-it.xml"),
                         junitBundles(),
                         awaitility(),
                         newConfiguration("org.apache.sling.jcr.base.internal.LoginAdminWhitelist")

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
@@ -29,7 +29,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.options.SystemPropertyOption;
 import org.ops4j.pax.exam.util.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +44,9 @@ import static org.ops4j.pax.exam.CoreOptions.vmOption;
 import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
 
+import java.util.Collection;
+import java.util.HashSet;
+
 public abstract class RepoInitTestSupport extends TestSupport {
 
     protected Session session;
@@ -52,13 +54,25 @@ public abstract class RepoInitTestSupport extends TestSupport {
     protected static final Logger log = LoggerFactory.getLogger(RepoInitTestSupport.class.getName());
 
     final String repositoriesURL = "https://repo1.maven.org/maven2@id=central";
-
+    
+    // artifact ID of all oak bundles
+    private static final String[] OAK_BUNDLES = new String[] {"oak-api","oak-blob",
+            "oak-blob-plugins","oak-commons","oak-core","oak-core-spi","oak-jcr",
+            "oak-lucene","oak-query-spi","oak-security-spi","oak-segment-tar","oak-store-composite",
+            "oak-store-document","oak-store-spi", "oak-jackrabbit-api"};
+    
+    private static final String[] JACKRABBIT_2x_BUNDLES = new String[] {"jackrabbit-data","jackrabbit-jcr-commons",
+            "jackrabbit-jcr-rmi","jackrabbit-spi-commons","jackrabbit-spi","jackrabbit-webdav"};
+  
     @Inject
     private SlingRepository repository;
 
     @Configuration
     public Option[] configuration() {
-        SlingOptions.versionResolver.setVersionFromProject("org.apache.jackrabbit", "oak-jackrabbit-api");
+        
+        updateOakVersion("1.44.0");
+        Collection<Option> nonExistingJackrabbitBundles = updateJackrabbit("2.22.0");
+        SlingOptions.versionResolver.setVersion("org.apache.sling", "org.apache.sling.jcr.oak.server", "1.2.10");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.repoinit.parser");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.commons.metrics");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.commons", "commons-lang3"); // for the metrics
@@ -75,6 +89,22 @@ public abstract class RepoInitTestSupport extends TestSupport {
                             .groupId("org.apache.jackrabbit")
                             .artifactId("oak-jackrabbit-api")
                             .versionAsInProject(),
+                        mavenBundle()
+                            .groupId("org.apache.jackrabbit")
+                            .artifactId("oak-store-spi")
+                            .versionAsInProject(),
+                        mavenBundle()
+                            .groupId("commons-codec")
+                            .artifactId("commons-codec")
+                            .version("1.14"),
+                        mavenBundle()
+                            .groupId("commons-io")
+                            .artifactId("commons-io")
+                            .version("2.11.0"),
+                        mavenBundle()
+                            .groupId("org.apache.tika")
+                            .artifactId("tika-core")
+                            .version("1.24.1"),
                         SlingOptions.logback(),
                         systemProperty("logback.configurationFile").value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback-it.xml"),
                         junitBundles(),
@@ -83,6 +113,8 @@ public abstract class RepoInitTestSupport extends TestSupport {
                                 .put("whitelist.bundles.regexp", "^PAXEXAM.*$")
                                 .asOption())
                 .add(additionalOptions())
+                .remove(nonExistingJackrabbitBundles)
+                .remove(mavenBundle().groupId("org.apache.jackrabbit").artifactId("jackrabbit-api").version(versionResolver))
                 .remove(
                         // remove our bundle under test to avoid duplication
                         mavenBundle()
@@ -91,6 +123,35 @@ public abstract class RepoInitTestSupport extends TestSupport {
                                 .version(versionResolver)));
     }
 
+    protected void updateOakVersion(String defaultVersion) {
+        for (int i=0;i< OAK_BUNDLES.length;i++) {
+            try {
+                SlingOptions.versionResolver.setVersionFromProject("org.apache.jackrabbit", OAK_BUNDLES[i]);
+            } catch (IllegalArgumentException e) {
+                // the version is not explicitly listed in the pom, so use the provided default version
+                SlingOptions.versionResolver.setVersion("org.apache.jackrabbit", OAK_BUNDLES[i], defaultVersion);
+            }
+        }
+    }
+    
+    protected Collection<Option> updateJackrabbit(String version) {
+        Collection<Option> nonExistingBundles = new HashSet<>();
+        for (int i=0;i< JACKRABBIT_2x_BUNDLES.length;i++) {
+            Option existingBundle = null;
+            try {
+                String artifactId=JACKRABBIT_2x_BUNDLES[i];
+                existingBundle = mavenBundle().groupId("org.apache.jackrabbit").artifactId(artifactId).versionAsInProject();
+                SlingOptions.versionResolver.setVersion("org.apache.jackrabbit", artifactId, version);
+            } catch (IllegalArgumentException e) {
+                nonExistingBundles.add(existingBundle);
+                
+            }
+        }
+        return nonExistingBundles;
+    }
+    
+    
+    
     protected Option[] additionalOptions() {
         return new Option[] {};
     }

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
@@ -55,7 +55,7 @@ public abstract class RepoInitTestSupport extends TestSupport {
 
     @Configuration
     public Option[] configuration() {
-        SlingOptions.versionResolver.setVersionFromProject("org.apache.jackrabbit", "jackrabbit-api");
+        SlingOptions.versionResolver.setVersionFromProject("org.apache.jackrabbit", "oak-jackrabbit-api");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.repoinit.parser");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.commons.metrics");
         SlingOptions.versionResolver.setVersionFromProject("org.apache.commons", "commons-lang3"); // for the metrics
@@ -68,6 +68,10 @@ public abstract class RepoInitTestSupport extends TestSupport {
                                 .groupId("org.apache.sling")
                                 .artifactId("org.apache.sling.repoinit.parser")
                                 .versionAsInProject(),
+                        mavenBundle()
+                            .groupId("org.apache.jackrabbit")
+                            .artifactId("oak-jackrabbit-api")
+                            .versionAsInProject(),
                         junitBundles(),
                         awaitility(),
                         newConfiguration("org.apache.sling.jcr.base.internal.LoginAdminWhitelist")

--- a/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/it/RepoInitTestSupport.java
@@ -122,7 +122,7 @@ public abstract class RepoInitTestSupport extends TestSupport {
                 SlingOptions.versionResolver.setVersionFromProject(JR_GID, OAK_BUNDLES[i]);
             } catch (IllegalArgumentException e) {
                 // the version is not explicitly listed in the pom, so use the provided default version
-                versionResolver.setVersion(JR_GID, OAK_BUNDLES[i], TARGET_OAK_VERSION);
+                SlingOptions.versionResolver.setVersion(JR_GID, OAK_BUNDLES[i], TARGET_OAK_VERSION);
             }
         }
         Collection<Option> nonExistingBundles = new HashSet<>();

--- a/src/test/resources/logback-it.xml
+++ b/src/test/resources/logback-it.xml
@@ -1,0 +1,23 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+    
+    <logger name="org.eclipse.jetty" level="warn">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+    
+    <logger name="org.ops4j.pax.exam.cm.internal" level="warn">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/src/test/resources/logback-it.xml
+++ b/src/test/resources/logback-it.xml
@@ -1,4 +1,22 @@
-<configuration>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+--><configuration>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">


### PR DESCRIPTION
As the PrivilegeCollections were added in Oak 1.42, all necessary dependencies must be updated; in order not to require the latest stuff, we just update to 1.44.

This PR does not contain any change in the functional code, but only dependencies and test code (when required).