### PR TITLE
SLING-12642 cache privileges and principals in the context of the invoking Jackrabbit Session

### DIFF
--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/AclUtil.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/AclUtil.java
@@ -168,7 +168,7 @@ public class AclUtil {
         AccessControlManager acMgr = pcsw.getAccessControlManager();
 
         final String[] privArray = privileges.toArray(new String[privileges.size()]);
-        final Privilege[] jcrPriv = AccessControlUtils.privilegesFromNames(acMgr, privArray);
+        final Privilege[] jcrPriv = pcsw.privilegesFromNames(privArray);
 
         JackrabbitAccessControlList acl = getAccessControlList(acMgr, jcrPath, true);
         checkState(acl != null, "No JackrabbitAccessControlList available for path {0}", jcrPath);
@@ -332,7 +332,7 @@ public class AclUtil {
 
                     LocalRestrictions restr = createLocalRestrictions(restrictionClauses, acl, pcsw.getSession());
                     Privilege[] privs =
-                            AccessControlUtils.privilegesFromNames(acMgr, privileges.toArray(new String[0]));
+                            pcsw.privilegesFromNames(privileges.toArray(new String[0]));
 
                     for (AccessControlEntry ace : acl.getAccessControlEntries()) {
                         Principal principal = ace.getPrincipal();
@@ -404,8 +404,8 @@ public class AclUtil {
                     modified = true;
                 }
             } else if (action == AclLine.Action.ALLOW) {
-                final Privilege[] privileges = AccessControlUtils.privilegesFromNames(
-                        acMgr, line.getProperty(PROP_PRIVILEGES).toArray(new String[0]));
+                final Privilege[] privileges = pcsw.privilegesFromNames(
+                        line.getProperty(PROP_PRIVILEGES).toArray(new String[0]));
                 for (String effectivePath : jcrPaths) {
                     if (acl == null) {
                         // no PrincipalAccessControlList available: don't fail if an equivalent path-based entry with
@@ -465,7 +465,7 @@ public class AclUtil {
             List<String> jcrPaths = getJcrPaths(pcsw.getSession(), line.getProperty(PROP_PATHS));
             LocalRestrictions restr = createLocalRestrictions(line.getRestrictions(), acl, pcsw.getSession());
             List<String> privNames = line.getProperty(PROP_PRIVILEGES);
-            Privilege[] privs = AccessControlUtils.privilegesFromNames(acMgr, privNames.toArray(new String[0]));
+            Privilege[] privs = pcsw.privilegesFromNames(privNames.toArray(new String[0]));
             Predicate<PrincipalAccessControlList.Entry> predicate = entry -> {
                 if (!jcrPaths.contains(entry.getEffectivePath())) {
                     return false;

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/CachingSessionWrapper.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/CachingSessionWrapper.java
@@ -39,7 +39,7 @@ import com.google.common.collect.Lists;
 /**
  * A simple wrapper around a session, which can cache the privilege resolution
  */
-public class PrivilegeCachingSessionWrapper {
+public class CachingSessionWrapper {
 
     JackrabbitSession session;
     JackrabbitAccessControlManager acMgr;
@@ -47,7 +47,7 @@ public class PrivilegeCachingSessionWrapper {
     Map<Privilege,List<Privilege>> privilegeToAggreate = new HashMap<>();
     Map<String,Principal> idToPrincipal = new HashMap<>();
     
-    public PrivilegeCachingSessionWrapper (Session session) {
+    public CachingSessionWrapper (Session session) {
         AclUtil.checkState(session instanceof JackrabbitSession,"A Jackrabbit Session is required");
         this.session = (JackrabbitSession) session;
         try {

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeCachingSessionWrapper.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeCachingSessionWrapper.java
@@ -89,7 +89,7 @@ public class PrivilegeCachingSessionWrapper {
     }
 
     /**
-     * If a privilege is an aggreated, return the privilges it contains, otherwise return the privilege itself
+     * If a privilege is an aggregated, return the privileges it contains, otherwise return the privilege itself
      * @param priv the privilege 
      * @return
      */
@@ -104,12 +104,15 @@ public class PrivilegeCachingSessionWrapper {
     }
 
     public Principal getPrincipal (String principalName) throws RepositoryException {
+        // Do not cache null principals
         if (idToPrincipal.containsKey(principalName)) {
-            return idToPrincipal.get(principalName);
-        } else {
-            Principal p = AccessControlUtils.getPrincipal(this.getSession(), principalName);
-            idToPrincipal.put(principalName, p);
-            return p;
+            Principal p = idToPrincipal.get(principalName);
+            if (p != null) {
+                return p;
+            }
         }
+        Principal p = AccessControlUtils.getPrincipal(this.getSession(), principalName);
+        idToPrincipal.put(principalName, p);
+        return p;
     }
 }

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeCachingSessionWrapper.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeCachingSessionWrapper.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.repoinit.impl;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
+
+/**
+ * A simple wrapper around a session, which can cache the privilege resolution
+ */
+public class PrivilegeCachingSessionWrapper {
+
+    JackrabbitSession session;
+    JackrabbitAccessControlManager acMgr;
+    
+    public PrivilegeCachingSessionWrapper (Session session) {
+        AclUtil.checkState(session instanceof JackrabbitSession,"A Jackrabbit Session is required");
+        this.session = (JackrabbitSession) session;
+        try {
+            AclUtil.checkState(session.getAccessControlManager() instanceof JackrabbitAccessControlManager, 
+                    "A Jachrabbit AccessControlManager is required");
+        } catch (RepositoryException e) {
+            throw new IllegalStateException("Cannot retrieve the AcccessControlManager");
+        }
+    }
+
+    public JackrabbitSession getSession() {
+        return session;
+    }
+
+    public JackrabbitAccessControlManager getAccessControlManager() {
+        return acMgr;
+    }
+
+}

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeCachingSessionWrapper.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/PrivilegeCachingSessionWrapper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.jcr.repoinit.impl;
 
+import java.security.Principal;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,6 +32,7 @@ import javax.jcr.security.Privilege;
 
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
+import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
 
 import com.google.common.collect.Lists;
 
@@ -43,6 +45,7 @@ public class PrivilegeCachingSessionWrapper {
     JackrabbitAccessControlManager acMgr;
     Map<String,Privilege> nameToPrivilegeMap = new HashMap<>();
     Map<Privilege,List<Privilege>> privilegeToAggreate = new HashMap<>();
+    Map<String,Principal> idToPrincipal = new HashMap<>();
     
     public PrivilegeCachingSessionWrapper (Session session) {
         AclUtil.checkState(session instanceof JackrabbitSession,"A Jackrabbit Session is required");
@@ -98,5 +101,15 @@ public class PrivilegeCachingSessionWrapper {
                 return Lists.newArrayList(p);
             }
         });
+    }
+
+    public Principal getPrincipal (String principalName) throws RepositoryException {
+        if (idToPrincipal.containsKey(principalName)) {
+            return idToPrincipal.get(principalName);
+        } else {
+            Principal p = AccessControlUtils.getPrincipal(this.getSession(), principalName);
+            idToPrincipal.put(principalName, p);
+            return p;
+        }
     }
 }

--- a/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
@@ -57,7 +57,7 @@ import org.apache.jackrabbit.oak.spi.security.principal.SystemUserPrincipal;
 import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.apache.sling.jcr.repoinit.impl.AclUtil;
-import org.apache.sling.jcr.repoinit.impl.PrivilegeCachingSessionWrapper;
+import org.apache.sling.jcr.repoinit.impl.CachingSessionWrapper;
 import org.apache.sling.jcr.repoinit.impl.RepoInitException;
 import org.apache.sling.jcr.repoinit.impl.TestUtil;
 import org.apache.sling.repoinit.parser.RepoInitParsingException;
@@ -805,7 +805,7 @@ public class PrincipalBasedAclTest {
         line.setProperty(AclLine.PROP_PRINCIPALS, Collections.singletonList(principal.getName()));
         line.setProperty(AclLine.PROP_PRIVILEGES, Collections.singletonList(Privilege.JCR_READ));
         line.setProperty(AclLine.PROP_PATHS, Collections.singletonList(":home:" + U.username + "#"));
-        AclUtil.setPrincipalAcl(new PrivilegeCachingSessionWrapper(U.adminSession), U.username, Collections.singletonList(line), false);
+        AclUtil.setPrincipalAcl(new CachingSessionWrapper(U.adminSession), U.username, Collections.singletonList(line), false);
 
         PrincipalAccessControlList acl = getAcl(principal, U.adminSession);
         assertNotNull(acl);

--- a/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/PrincipalBasedAclTest.java
@@ -57,6 +57,7 @@ import org.apache.jackrabbit.oak.spi.security.principal.SystemUserPrincipal;
 import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.apache.sling.jcr.repoinit.impl.AclUtil;
+import org.apache.sling.jcr.repoinit.impl.PrivilegeCachingSessionWrapper;
 import org.apache.sling.jcr.repoinit.impl.RepoInitException;
 import org.apache.sling.jcr.repoinit.impl.TestUtil;
 import org.apache.sling.repoinit.parser.RepoInitParsingException;
@@ -804,7 +805,7 @@ public class PrincipalBasedAclTest {
         line.setProperty(AclLine.PROP_PRINCIPALS, Collections.singletonList(principal.getName()));
         line.setProperty(AclLine.PROP_PRIVILEGES, Collections.singletonList(Privilege.JCR_READ));
         line.setProperty(AclLine.PROP_PATHS, Collections.singletonList(":home:" + U.username + "#"));
-        AclUtil.setPrincipalAcl(U.adminSession, U.username, Collections.singletonList(line), false);
+        AclUtil.setPrincipalAcl(new PrivilegeCachingSessionWrapper(U.adminSession), U.username, Collections.singletonList(line), false);
 
         PrincipalAccessControlList acl = getAcl(principal, U.adminSession);
         assertNotNull(acl);

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/AclUtilTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/AclUtilTest.java
@@ -607,7 +607,7 @@ public class AclUtilTest {
             boolean contained)
             throws RepositoryException {
         AclUtil.LocalAccessControlEntry localAce =
-                new AclUtil.LocalAccessControlEntry(principal(username), privileges(privilegeNames), isAllow);
+                new AclUtil.LocalAccessControlEntry(toPCSessionWrapper(U.adminSession),principal(username), privileges(privilegeNames), isAllow);
 
         if (contained) {
             assertTrue(

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/AclUtilTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/AclUtilTest.java
@@ -627,7 +627,7 @@ public class AclUtilTest {
         return AccessControlUtils.privilegesFromNames(U.adminSession, privilegeNames);
     }
 
-    private static PrivilegeCachingSessionWrapper toPCSessionWrapper (Session session) {
-        return new PrivilegeCachingSessionWrapper(session);
+    private static CachingSessionWrapper toPCSessionWrapper (Session session) {
+        return new CachingSessionWrapper(session);
     }
 }

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/AclUtilTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/AclUtilTest.java
@@ -243,7 +243,7 @@ public class AclUtilTest {
             assertNull(((JackrabbitSession) session).getUserManager().getAuthorizable(EveryonePrincipal.getInstance()));
 
             AclUtil.setAcl(
-                    session,
+                    toPCSessionWrapper(session),
                     Collections.singletonList(EveryonePrincipal.NAME),
                     Collections.singletonList(PathUtils.ROOT_PATH),
                     Collections.singletonList(Privilege.JCR_READ),
@@ -273,7 +273,7 @@ public class AclUtilTest {
             U.adminSession.save();
 
             AclUtil.setAcl(
-                    U.adminSession,
+                    toPCSessionWrapper(U.adminSession),
                     Collections.singletonList(principal.getName()),
                     Collections.singletonList(PathUtils.ROOT_PATH),
                     Collections.singletonList(Privilege.JCR_READ),
@@ -307,7 +307,7 @@ public class AclUtilTest {
             U.adminSession.save();
 
             AclUtil.setAcl(
-                    U.adminSession,
+                    toPCSessionWrapper(U.adminSession),
                     Collections.singletonList(U.username),
                     Collections.singletonList(PathUtils.ROOT_PATH),
                     Collections.singletonList(Privilege.JCR_READ),
@@ -342,7 +342,7 @@ public class AclUtilTest {
 
         List<String> paths = Collections.singletonList(":home:" + U.username + "#");
         AclUtil.setAcl(
-                U.adminSession,
+                toPCSessionWrapper(U.adminSession),
                 Collections.singletonList(U.username),
                 paths,
                 Collections.singletonList(Privilege.JCR_READ),
@@ -374,7 +374,7 @@ public class AclUtilTest {
 
         List<String> paths = Collections.singletonList(":home:" + U.username + "," + gr.getID() + "#");
         AclUtil.setAcl(
-                U.adminSession,
+                toPCSessionWrapper(U.adminSession),
                 Collections.singletonList(U.username),
                 paths,
                 Collections.singletonList(Privilege.JCR_READ),
@@ -399,7 +399,7 @@ public class AclUtilTest {
 
         List<String> paths = Arrays.asList(":home:" + U.username + "#", ":repository", PathUtils.ROOT_PATH);
         AclUtil.setAcl(
-                U.adminSession,
+                toPCSessionWrapper(U.adminSession),
                 Collections.singletonList(U.username),
                 paths,
                 Collections.singletonList(Privilege.JCR_ALL),
@@ -450,7 +450,7 @@ public class AclUtilTest {
 
         List<String> paths = Collections.singletonList(":home:" + U.username + "," + gr.getID() + "#/profiles/private");
         AclUtil.setAcl(
-                U.adminSession,
+                toPCSessionWrapper(U.adminSession),
                 Collections.singletonList(U.username),
                 paths,
                 Collections.singletonList(Privilege.JCR_READ),
@@ -504,7 +504,7 @@ public class AclUtilTest {
 
         List<String> paths = Collections.singletonList(":home:" + gr.getID() + "," + U.username + "#");
         AclUtil.setAcl(
-                U.adminSession,
+                toPCSessionWrapper(U.adminSession),
                 Collections.singletonList(U.username),
                 paths,
                 Collections.singletonList(Privilege.JCR_READ),
@@ -537,7 +537,7 @@ public class AclUtilTest {
     public void testSetAclWithHomePathMissingTrailingHash() throws Exception {
         List<String> paths = Collections.singletonList(":home:" + U.username);
         AclUtil.setAcl(
-                U.adminSession,
+                toPCSessionWrapper(U.adminSession),
                 Collections.singletonList(U.username),
                 paths,
                 Collections.singletonList(Privilege.JCR_READ),
@@ -548,7 +548,7 @@ public class AclUtilTest {
     public void testSetAclWithHomePathUnknownUser() throws Exception {
         List<String> paths = Collections.singletonList(":home:alice#");
         AclUtil.setAcl(
-                U.adminSession,
+                toPCSessionWrapper(U.adminSession),
                 Collections.singletonList(U.username),
                 paths,
                 Collections.singletonList(Privilege.JCR_READ),
@@ -559,7 +559,7 @@ public class AclUtilTest {
     public void repeatedSetAclCallIsNoOp() throws Throwable {
         final Session session = U.adminSession;
         final ThrowingRunnable setAcls = () -> AclUtil.setAcl(
-                session,
+                toPCSessionWrapper(session),
                 Collections.singletonList(U.username),
                 Arrays.asList(":home:" + U.username + "#", ":repository", PathUtils.ROOT_PATH),
                 Collections.singletonList(Privilege.JCR_ALL),
@@ -578,7 +578,7 @@ public class AclUtilTest {
     public void nullRestrictionClauseAndNullOptionsAreHandled() {
         final Session session = U.adminSession;
         Assertions.assertDoesNotThrow(() -> AclUtil.setAcl(
-                session,
+                toPCSessionWrapper(session),
                 Collections.singletonList(U.username),
                 Collections.singletonList(PathUtils.ROOT_PATH),
                 Collections.singletonList(Privilege.JCR_READ),
@@ -625,5 +625,9 @@ public class AclUtilTest {
 
     private Privilege[] privileges(String... privilegeNames) throws RepositoryException {
         return AccessControlUtils.privilegesFromNames(U.adminSession, privilegeNames);
+    }
+
+    private static PrivilegeCachingSessionWrapper toPCSessionWrapper (Session session) {
+        return new PrivilegeCachingSessionWrapper(session);
     }
 }

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/ManyServiceUsersTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/ManyServiceUsersTest.java
@@ -85,7 +85,7 @@ public class ManyServiceUsersTest {
 
                 try {
                     AclUtil.setAcl(
-                            new PrivilegeCachingSessionWrapper(otherSession),
+                            new CachingSessionWrapper(otherSession),
                             Arrays.asList(username),
                             Arrays.asList(path),
                             Arrays.asList("jcr:read"),

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/ManyServiceUsersTest.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/ManyServiceUsersTest.java
@@ -85,7 +85,7 @@ public class ManyServiceUsersTest {
 
                 try {
                     AclUtil.setAcl(
-                            otherSession,
+                            new PrivilegeCachingSessionWrapper(otherSession),
                             Arrays.asList(username),
                             Arrays.asList(path),
                             Arrays.asList("jcr:read"),

--- a/src/test/java/org/apache/sling/jcr/repoinit/impl/TestUtil.java
+++ b/src/test/java/org/apache/sling/jcr/repoinit/impl/TestUtil.java
@@ -76,13 +76,13 @@ public class TestUtil {
         username = "user_" + id;
     }
 
-    public List<Operation> parse(String... inputLines) throws RepoInitParsingException {
+    public static List<Operation> parse(String... inputLines) throws RepoInitParsingException {
         try (final StringReader r = new StringReader(String.join("\n", inputLines))) {
             return new RepoInitParserService().parse(r);
         }
     }
 
-    private void assertPathContains(Authorizable u, String pathShouldContain) throws RepositoryException {
+    private static void assertPathContains(Authorizable u, String pathShouldContain) throws RepositoryException {
         if (pathShouldContain != null) {
             final String path = u.getPath();
             assertTrue("Expecting path " + path + " to contain " + pathShouldContain, path.contains(pathShouldContain));


### PR DESCRIPTION
In the AclUtil there are many occassions where privileges and principals are resolved over and over again (probably many times the same).

In order to remove the redundant retrieval I added ``CachingSesssionWrapper`` which is passed instead of the session; by default the wrapped session is used, but the following 2 functionalities are executed in an optimized way by the CachingSessionWrapper:

* ``privilegesFromNames`` (convert the privilege names into privilege objects)
* ``expandPrivilege`` ( to expand aggregated privileges into the contained privileges)
* ``getPrincipal`` ( to retrieve a principal for a given principal name)

All these results are cached within the CachingSessionWrapper. As this object shares the same lifetime as the ``session`` object itself, and as the results are immutable, it's safe to do so.

Note: ``getPrincipal`` is safe here, as no principals are removed here.


