### PR TITLE
SLING-12668 Forced multivalue property with single value is not stored as multiple property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.repoinit.parser</artifactId>
-            <version>1.9.0</version>
+            <version>1.9.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/jcr/repoinit/impl/NodePropertiesVisitor.java
+++ b/src/main/java/org/apache/sling/jcr/repoinit/impl/NodePropertiesVisitor.java
@@ -291,7 +291,7 @@ class NodePropertiesVisitor extends DoNothingVisitor {
                 // note: Node#setProperty() touches the node even if the property value is unchanged
                 //       and thus needs to be explicitly avoided
                 if (hasPropertyChange(oldProperty, newType, newValues)) {
-                    if (newValues.length == 1) {
+                    if (newValues.length == 1 && !pl.isMultiple()) {
                         n.setProperty(pName, newValues[0], newType);
                     } else {
                         n.setProperty(pName, newValues, newType);

--- a/src/test/resources/repoinit.txt
+++ b/src/test/resources/repoinit.txt
@@ -112,3 +112,12 @@ set properties on authorizable(bob)/nested,authorizable(grpB)/nested
   set quotedMix to "quoted", non-quoted, "the last \" one"
   set nested/someInteger{Long} to 42
 end
+
+ensure nodes (nt:unstructured) /forcedMultiValue with properties
+  set multiValue{String[]} to "item1","item2"
+  set singleMultiValue{String[]} to "single"
+  set emptyMultiValue{String[]} to
+  set longMultiValue{Long[]} to 1243,5678
+  set singleLongMultiValue{Long[]} to 1243
+  set emptyLongMultiValue{Long[]} to
+end


### PR DESCRIPTION
When properties are set with forcer multiple type like this:
```
ensure nodes (nt:unstructured) /forcedMultiValue with properties
  set multiValue{String[]} to "item1","item2"
  set singleMultiValue{String[]} to "single"
  set emptyMultiValue{String[]} to
end 
```

in all those cases the property should be stored as multiple property, regardless if the actual number of values provided.

this PR depends on https://github.com/apache/sling-org-apache-sling-repoinit-parser/pull/30